### PR TITLE
[Chore] Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for penguintechinc/waddlebot
+#
+# The org default-branch ruleset sets require_code_owner_review, so every PR
+# into the default branch needs an approving review from someone listed here.
+#
+# Owner is @Chromeninja. PenguinzTech authors PRs here, so a different owner
+# is what makes the review requirement satisfiable.
+
+*   @Chromeninja


### PR DESCRIPTION
## Summary
The org default-branch ruleset sets `require_code_owner_review`, so every PR into `main` needs an approving review from someone in CODEOWNERS. This repo had none, so the requirement matched nobody. Adds `.github/CODEOWNERS`:

```
*   @Chromeninja
```

## Test plan
- [x] File added at `.github/CODEOWNERS`
- [ ] Confirm review requirement now resolves to a reviewer on this PR

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## Summary by Sourcery

Chores:
- Introduce a .github/CODEOWNERS file assigning repository ownership to @Chromeninja.