### PR TITLE
docs: v3.0.x SCBM architecture design and migration plan

### DIFF
--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -124,6 +124,64 @@ hold global admin scope and still not swap a community's App platform-wide.
 The two ladders look alike and must not be collapsed into one mechanism: one answers *who
 may act on what*, the other answers *which implementation serves this slot here*.
 
+## Service identity: SPIFFE/SPIRE
+
+User identity answers *who is acting*. Service identity answers *which workload is calling*.
+Both are required; neither substitutes for the other.
+
+Every pod gets an X.509-SVID from a SPIRE agent over the Workload API. SPIFFE IDs follow
+the house pattern from `penguintech.md`:
+
+```
+spiffe://penguintech.io/{env}/{service}
+```
+
+Collapsing to seven containers makes this tractable: seven registration entries per
+environment instead of forty.
+
+### Two deployment modes, one values flip apart
+
+SkausWatch already ships `skauswatch-spire` — a nested SPIFFE/SPIRE trust authority for the
+single `penguintech.io` trust domain, root plus per-cluster child servers. v3 adopts its
+topology rather than inventing one:
+
+| Mode | Configuration | When |
+|------|---------------|------|
+| **Independent** | `topology.role: child`, `topology.upstreamRoot.enabled: false` | a standalone Waddles deployment; the child runs its own self-signed CA |
+| **Centralized** | `topology.role: child`, `topology.upstreamRoot.enabled: true` | nested under an external root such as SkausWatch, sharing the `penguintech.io` trust domain |
+
+Deploy as `child` with the upstream disabled, **not** as `standalone`. The chart is written
+so a child promotes to nested mode without a `topology.role` change — it needs only a join
+token and the root's trust bundle. Choosing `standalone` would buy nothing now and force a
+topology change to federate later.
+
+### How it composes with the rest of this design
+
+SPIFFE is one of three identity mechanisms here, and they answer different questions:
+
+| Mechanism | Answers | Scope |
+|-----------|---------|-------|
+| X.509-SVID | which *workload* is calling | per service |
+| Machine JWT | what that call is *allowed to do* | per service, scoped |
+| Valkey ACL user | which *tenant's* data it may touch | per (tenant, stage) |
+
+An SVID does not carry tenancy, so it complements the per-tenant ACL users rather than
+replacing them. A compromised stage still authenticates as itself; what the tenant ACL
+constrains is which keys it can reach.
+
+Per `security.md`, mTLS does **not** remove the JWT requirement: every inter-service call
+carries a short-lived signed JWT regardless of transport, whether or not SPIFFE is live for
+that call. The two remaining call shapes after consolidation:
+
+- **stage → `svc-core` gRPC** — mTLS with SVIDs, plus the machine JWT.
+- **stage → Valkey** — Valkey speaks TLS with client certificates, so the SVID can
+  authenticate the connection while the per-tenant ACL user authorizes the keyspace.
+
+Being SPIFFE-*ready* is the requirement even where SPIRE is not deployed: services accept an
+mTLS/X.509-SVID identity as a first-class mechanism, so enabling SPIRE in an environment is
+configuration rather than a rewrite. Nothing in waddlebot implements this today — the
+codebase has zero SPIFFE references outside standards documents.
+
 ## Vocabulary
 
 The word "module" currently means three different things in this repo, which is why the
@@ -568,13 +626,17 @@ regardless of topology.
 
 These need a call before the phases they block:
 
-1. **`core/module_rtc` is Go.** It is the seed of Social's conferencing story — precisely
+1. **Which SPIRE root, if any.** Independent (self-signed child) is the default and needs no
+   decision. Nesting under SkausWatch's root needs a join token minted there and its trust
+   bundle published to this cluster — a cross-team coordination, not a code change. Blocks
+   nothing; decide per environment.
+2. **`core/module_rtc` is Go.** It is the seed of Social's conferencing story — precisely
    where it would need to grow, which the Go phase-out rule says it should not. Rewrite in
    Rust during P3, or grant a documented exception. Blocks P3.
-2. **The `services/` tree is a half-finished consolidation** with documented orphaned
+3. **The `services/` tree is a half-finished consolidation** with documented orphaned
    duplicates (`docs/MODULE_CANONICAL_SOURCES.md`). v3 either completes it or deletes it;
    keeping both trees is what produced the divergence. Blocks P0.
-3. **Tier mapping is not yet set.** Which Features land in Free vs Professional vs
+4. **Tier mapping is not yet set.** Which Features land in Free vs Professional vs
    Enterprise is a commercial decision, not an architectural one. Blocks the
    `seeds/waddles.py` definition in P1.
 
@@ -584,7 +646,7 @@ Detail lives in the companion plan. Summary:
 
 | Phase | Work | Gate to exit |
 |-------|------|--------------|
-| P0 | Extract Core; resolve the `services/` tree; **propagate tenant scoping into the Python fleet**; Valkey + Streams as the stage transport; collapse to seven containers | One tree only; cross-tenant isolation, redelivery, DLQ and idempotency tests all pass after first being made to fail; zero Alpine or unpinned images; gRPC call sites classified with counts |
+| P0 | Extract Core; resolve the `services/` tree; **propagate tenant scoping into the Python fleet**; Valkey + Streams as the stage transport; SPIFFE/SPIRE workload identity; collapse to seven containers | One tree only; cross-tenant isolation, redelivery, DLQ and idempotency tests all pass after first being made to fail; zero Alpine or unpinned images; gRPC call sites classified with counts |
 | P1 | App manifest, registry, binding resolution; rename to `app_installations`; convert 2–3 Bot units as proof | A community can rebind a Feature to a non-default App |
 | P2 | Bot — all triggers/actions/interactions become Apps | v2.2.x Bot parity, all as Apps |
 | P3 | Social — community, presence, RTC, browser-source as Apps | v2.2.x Social parity |
@@ -606,4 +668,6 @@ Detail lives in the companion plan. Summary:
 | Valkey becomes a single point of failure for the whole event path | It already is for cache and sessions; P0 sizes it for stream retention and configures persistence deliberately rather than inheriting cache defaults |
 | Per-tenant streams and ACL users grow linearly with the tenant roster | Pool per tenant with idle eviction and an active-tenant set; revisit in the low thousands, then shard via Cluster hash tags or dedicated Valkey rather than dropping isolation |
 | A "missing tenant means default" fallback outlives the migration and becomes a bypass | The fallback has a recorded cutoff date, after which unclaimed tokens are rejected |
+| SPIRE deployed standalone, then federation with SkausWatch needs a topology change | Deploy as `child` with the upstream disabled from the start; promotion is a values flip plus a join token |
+| mTLS is treated as replacing the inter-service JWT | `security.md` requires both regardless of transport; the SVID-required test does not assert the JWT, so both need their own gate |
 | CI rebuilds everything on any change | Seven images with path-filtered workflows, as `build-*.yml` already does per module |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -791,6 +791,96 @@ its source; rows sourced from "this design" are proposals, not standards.
 | Advanced analytics | Enterprise | `critical-rules.md` |
 | Dedicated Valkey / per-tenant infrastructure isolation | Enterprise | this design — see Transport limits |
 
+### Two deployment topologies
+
+Waddles ships in two shapes, and they differ in *who owns the deployment* — which changes
+where entitlement attaches:
+
+| | Self-hosted | SaaS (`waddles.app`) |
+|---|---|---|
+| Owner | the customer | PenguinTech |
+| Tenants | 1 (Free/Pro) or many (Enterprise) | many — one per Enterprise customer, plus PenguinTech's default |
+| Customer buys | a licence for their deployment | **a tenant**, or **an upgrade to their community inside our default tenant** |
+| Entitlement attaches at | the tenant | the tenant *or* the community |
+
+The second SaaS shape is the one that breaks an assumption elsewhere in this design.
+Self-serve customers do not get a tenant at all — they get a **community inside PenguinTech's
+default tenant**, and they pay to upgrade *that community*. Many paying customers at different
+tiers therefore share one tenant.
+
+#### Entitlement resolves narrowest-first, like App binding
+
+Tier can no longer be a property of the tenant alone:
+
+```
+community entitlement  →  tenant entitlement
+```
+
+The same shape as App binding (`community → tenant → default`), and for the same reason: the
+narrower scope is where the specific answer lives. In self-hosted deployments entitlement is
+set at the tenant and communities inherit it; in SaaS shape two it is set per community and
+overrides the default tenant's Free baseline.
+
+This makes the structural caps clearer rather than murkier — they describe what a *customer*
+gets, not what a deployment contains:
+
+| Customer tier | Self-hosted | SaaS |
+|---------------|-------------|------|
+| Free | one deployment, the default tenant | a community in PenguinTech's default tenant |
+| Professional | one deployment, the default tenant | a community in PenguinTech's default tenant |
+| Enterprise | own deployment, many tenants | **their own tenant** |
+
+PenguinTech's SaaS deployment holds many tenants because PenguinTech operates it, not because
+it holds an Enterprise licence. Deployment size and customer tier are unrelated.
+
+#### The domain is a mode switch, not a bypass
+
+SaaS mode activates on **`waddles.app`** or **`waddles.penguincloud.tech`**. The hostname
+therefore selects one of three modes, rather than toggling licensing on and off:
+
+| Domain | Mode | Entitlement |
+|--------|------|-------------|
+| `waddles.app`, `waddles.penguincloud.tech` | **SaaS** | per tenant *or* per community, from billing — **never bypassed** |
+| `*.penguintech.cloud`, `*.penguincloud.io` | internal (beta/dev) | bypassed — PenguinTech's own non-production |
+| anything else | self-hosted | per-tenant licence validated against `license.penguintech.io` |
+
+Reading the domain as a mode rather than a bypass is what keeps the SaaS chargeable. The two
+questions collapse into one in self-hosted deployments and separate in SaaS:
+
+| Question | Answered by | In SaaS |
+|----------|-------------|---------|
+| Is this *deployment* licensed to run? | the mode | yes — PenguinTech owns it |
+| What tier is this *customer*? | the entitlement lookup | **never by the hostname** |
+
+**A standards conflict to settle before launch.** `penguintech.md` lists product-specific
+`.app` domains as hardcoded licence-bypass domains, and `waddles.app` is the product domain
+per `penguintech-reference`. Applied literally, every paying SaaS customer would get full
+entitlement free. Today's code happens to be correct — `PREMIUM_BYPASS_DOMAINS` in
+`video_proxy_module` lists only `waddlebot.penguintech.io`, `waddles.penguintech.cloud` and
+`waddles.penguincloud.io` — but that is luck rather than design. Raise the wording with the
+standards owner; `waddles.penguincloud.tech` is also outside every current bypass pattern and
+needs adding to the mode list explicitly.
+
+#### Where community-scoped entitlement lives
+
+The licence server has no sub-tenant entitlement scope — entitlement is licence-level. SaaS
+shape two needs entitlement *below* the tenant, so it does not belong there:
+
+| Entitlement | System | Covers |
+|-------------|--------|--------|
+| Deployment / tenant tier | licence server | self-hosted licences; Enterprise tenants in SaaS |
+| **Community tier within a shared tenant** | **marketplace subscriptions** | SaaS self-serve customers |
+| Third-party App access | marketplace subscriptions | both topologies |
+
+The marketplace is already a billing system — `subscriptionController`, `premiumController`,
+seat limits, overage pricing. Extending it to carry first-party Feature entitlement for a
+community is a smaller change than adding a sub-tenant scope to the licence server for the
+only two products that need it.
+
+That does widen the marketplace's role: it currently gates third-party Apps, and in SaaS it
+would also gate first-party Features for communities. State that deliberately rather than
+letting it happen — it makes the marketplace load-bearing for revenue, not just for extensions.
+
 ### Structural caps
 
 Two caps are structural rather than feature flags — they limit how many of a thing exists,
@@ -861,6 +951,8 @@ Detail lives in the companion plan. Summary:
 | Per-tenant streams and ACL users grow linearly with the tenant roster | Pool per tenant with idle eviction and an active-tenant set; revisit in the low thousands, then shard via Cluster hash tags or dedicated Valkey rather than dropping isolation |
 | A "missing tenant means default" fallback outlives the migration and becomes a bypass | The fallback has a recorded cutoff date, after which unclaimed tokens are rejected |
 | The multi-tenant path rots because Free and Professional never exercise it | Single-tenant runs the identical code with N=1; no `if tenant == "default"` shortcut is permitted anywhere |
+| `waddles.app` is added to the bypass list per the standard, and the SaaS becomes free for every customer | The hostname selects a mode, never an entitlement; a test asserts a Free community on `waddles.app` resolves to Free |
+| The marketplace becomes load-bearing for revenue but is sized as an extension catalogue | Stated deliberately in the design; its availability requirements are set for the billing path, not the browse path |
 | SPIRE deployed standalone, then federation with SkausWatch needs a topology change | Deploy as `child` with the upstream disabled from the start; promotion is a values flip plus a join token |
 | mTLS is treated as replacing the inter-service JWT | `security.md` requires both regardless of transport; the SVID-required test does not assert the JWT, so both need their own gate |
 | mTLS is enabled without a peer SPIFFE ID allowlist, so any workload in the trust domain is accepted | Per-service accepted-peer lists, with a test asserting a valid-but-unlisted SVID is rejected |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -11,6 +11,10 @@ layered platform: a mandatory **Core**, four globally-toggleable **Modules** (So
 Customer, Bot, Marketing), **Features** that Modules group, and **Apps** that implement
 those Features and can be swapped per tenant or per community through the marketplace.
 
+Deployment collapses to **seven containers** along an ingest → process → action pipeline.
+The logical hierarchy and the container topology are deliberately independent — conflating
+them is what produced the ~40.
+
 The model is Nextcloud's: a core platform plus an app store, where the shipped defaults
 are themselves apps. Nothing is a privileged built-in, because a built-in that cannot be
 replaced makes the extension point decorative.
@@ -40,14 +44,16 @@ The scoping ladder narrows at each level, and each level uses a different mechan
 | Level | Enable/disable scope | Mechanism | Who decides |
 |-------|---------------------|-----------|-------------|
 | Core | always on | mandatory dependency | nobody — it is not optional |
-| Module | global / cluster-wide | Helm `enabled:` + global toggle | cluster operator |
+| Module | global / cluster-wide | values flag; pipeline containers load its App bundles | cluster operator |
 | Feature | per tenant | license tier × PostHog flag | licensing + rollout |
 | App | per tenant and/or community | marketplace binding | tenant admin / community admin |
 
-A Module is either deployed or it is not. There is deliberately no per-tenant Module
-toggle: that would mean running Social's services while denying them to a tenant, paying
-the operational cost of a Module nobody can reach. Per-tenant variation belongs one level
-down, at Features.
+A Module is either on or off for the whole cluster. There is deliberately no per-tenant
+Module toggle: per-tenant variation belongs one level down, at Features, where it costs a
+flag lookup rather than a deployment topology.
+
+Note that "off" means its Apps are not loaded, not that a pod disappears — containers are
+organised by role rather than by Module. See Deployment.
 
 ## Identity and data scoping
 
@@ -130,7 +136,7 @@ v3 splits these:
 | **Module** | one of four product surfaces, a grouping of Features | Social, Customer, Bot, Marketing |
 | **Feature** | a versioned capability contract inside a Module | `bot.shoutout`, `social.polls` |
 | **App** | an implementation of a Feature, installable and bindable | `shoutout-default`, `acme-shoutout-pro` |
-| **Service** | a deployable container | `social-api`, `bot-router` |
+| **Service** | a deployable container, a pipeline stage or a supporting role | `svc-ingest`, `svc-process` |
 
 Renaming `hub_module_installations` to `app_installations` is part of P1. The existing
 column meaning does not change; only the name stops lying.
@@ -219,12 +225,18 @@ extension point is real rather than nominal.
 ```yaml
 id: shoutout-default
 module: bot
+stages: [process, action]       # which pipeline containers load it
 provides: [bot.shoutout@1]      # Feature contracts, versioned
 requires_core: [identity, event-bus, tenancy]
+requires_scopes: [bot.command:write]
 min_tier: free
 flag: waddles.bot.shoutout
 vendor: penguintech             # first-party
 ```
+
+`stages` is what lets a container decide, at load time, whether an App is its concern.
+A first-party App may span stages; a third-party App never does — it is reached over the
+network from whichever stage invokes it, so its manifest declares the calling stage only.
 
 ### Binding resolution
 
@@ -253,6 +265,34 @@ These are separate and both already half-exist:
 A third-party App may implement a Feature the tenant's tier does not entitle. The Feature
 gate wins: buying an App does not buy the Feature slot it plugs into.
 
+### Third-party Apps never run in our process
+
+A third-party App is always reached across a network boundary, in one of exactly two
+shapes. Both are already implemented in `vendorExecutionService.executeCommand()`:
+
+| Model | Direction | Transport | Auth |
+|-------|-----------|-----------|------|
+| `webhook_push` | we call out to them | POST to the App's `webhook_url`, response is the result | HMAC-SHA256 over the payload, `webhook_secret` |
+| `rest_pull` | our API to their API | POST to `api_base_url + /execute` | `api_key` bearer, `oauth2_client_credentials` bearer, or HMAC fallback via `X-WaddleBot-Signature` |
+
+`webhook_push` covers external ecosystems and serverless targets — Lambda, GCP Functions,
+OpenWhisk, or any vendor endpoint. `rest_pull` covers standing third-party integrations
+with their own API surface.
+
+We never execute vendor code in-process, and vendors never execute ours. Three consequences
+worth stating, because they shape decisions elsewhere in this design:
+
+- **Container consolidation is safe.** Collapsing first-party services into seven role
+  containers puts no untrusted code in a shared process, because untrusted code was never
+  in-process to begin with.
+- **Every third-party App is a network hop**, so a Feature served by one inherits a timeout
+  and a failure mode a first-party App does not. Feature contracts must therefore specify
+  timeout and fallback behaviour, not just a signature — `webhook_timeout_ms` already
+  exists per module and defaults to 5000ms.
+- **Egress is a policy surface.** Per `security.md`, outbound is deny-by-default with an
+  allowlist; each installed App's endpoint becomes an allowlist entry scoped to the
+  installing tenant, not a blanket open egress.
+
 ### What already exists
 
 More of this is built than the naming suggests:
@@ -267,18 +307,118 @@ between community and default.
 
 ## Deployment
 
-Each Module is a Helm sub-chart with an `enabled:` condition, defaulting off except Core.
-Turning a Module off removes its services entirely rather than leaving them running behind
-a flag — an unreachable Module should cost nothing.
+**Container topology is a packaging decision, deliberately decoupled from the logical
+model.** Modules, Features and Apps are code and configuration; they do not each get a pod.
+v2.2.x's ~40 co-equal containers are the cost of having conflated the two.
+
+The spine is a **pipeline**, which is already the shape of the system — `trigger/receiver`
+→ `processing/router` → `action/*` — just spread across forty containers instead of three:
+
+```
+        ┌──────────────┐      ┌──────────────┐      ┌──────────────┐
+inbound │  svc-ingest  │ ───▶ │ svc-process  │ ───▶ │  svc-action  │ outbound
+        └──────────────┘      └──────────────┘      └──────────────┘
+         platform events       event bus, routing,    actions, interactions,
+         + webhooks            command dispatch,      third-party App calls
+                               workflow
+```
+
+Each stage scales on a different axis, which is the reason they are separate and the test
+for whether a future split is justified:
+
+| Container | Carries | Scales on |
+|-----------|---------|-----------|
+| `svc-ingest` | platform receivers (Twitch, Discord, Slack, Teams, YouTube, Kick, GoogleChat, Mattermost), inbound webhooks | count of long-lived inbound connections |
+| `svc-process` | Core event bus, routing, Bot command dispatch, workflow | event volume |
+| `svc-action` | outbound actions, interaction Apps, third-party App calls | outbound throughput and remote latency |
+
+### Modules cut across stages
+
+A Module is a **vertical**; the pipeline is **horizontal**. A Module is not assigned to a
+stage — it contributes code to however many stages it needs, from one to all three:
+
+| Module | `svc-ingest` | `svc-process` | `svc-action` | also |
+|--------|-------------|---------------|--------------|------|
+| **Bot** | platform receivers | command dispatch, cooldowns | outbound actions, interactions | — |
+| **Social** | chat/presence inbound | presence fan-out, routing | chat outbound, browser sources | `svc-rtc` |
+| **Marketing** | platform analytics webhooks | scheduling | publishing to X/FB/IG | — |
+| **Customer** | — | pipeline automation | notifications | mostly `hub-api` CRUD |
+
+Three consequences:
+
+- **"Module off" is a per-stage operation.** Disabling Social means not loading its bundles
+  in ingest *and* process *and* action, and not scheduling `svc-rtc`. A flag honoured in
+  only some stages is a half-disabled Module, which is worse than either state.
+- **An App declares its stage.** An App belongs to one Module and targets one or more
+  pipeline stages; the manifest carries both, and the stage determines which container
+  loads it.
+- **Splitting a stage per Module may mean splitting several.** Giving Bot its own action
+  container does not isolate Bot — its ingest and process code still shares. Isolating a
+  Module properly means splitting every stage it touches, which is why the escape hatch is
+  reserved for evidence rather than anticipation.
+
+Four more containers, each for a specific reason rather than by default:
+
+| Container | Why it is not in the pipeline |
+|-----------|-------------------------------|
+| `hub-webui` | static SPA assets; different cache and scaling profile entirely |
+| `hub-api` | admin + marketplace + tenant management; low-volume admin traffic |
+| `svc-core` | identity, security, credentials, entitlement — every stage depends on it, so it must not redeploy on an admin-UI change |
+| `svc-rtc` | WebRTC/SFU media; UDP transport and media scaling share nothing with HTTP request handling |
+
+Seven, from ~40.
+
+`svc-core` is deliberately not folded into `hub-api`: doing so would put every service's
+auth path on the admin API's deploy cadence, so a webui change could take down
+authentication. `svc-rtc` cannot co-locate at all — media transport constrains and is
+constrained by anything sharing its pod.
+
+The router split is a **code and dependency-direction** split, not a deployment one. Both
+halves ship in `svc-process`; "Modules never import each other" is enforced at package
+level, where it is actually checkable, not by pod boundaries.
+
+### What Module toggling means now
+
+This is the honest trade-off of consolidation, and it is a real change from a
+pod-per-Module design:
 
 ```yaml
-core:      { enabled: true }   # not overridable
 modules:
   bot:       { enabled: true }
   social:    { enabled: true }
-  customer:  { enabled: false }
+  customer:  { enabled: false }   # its Apps are not loaded; no pod disappears
   marketing: { enabled: false }
 ```
+
+Turning a Module off stops the containers from loading that Module's App bundles. It
+does **not** remove a workload. Consequences to accept knowingly:
+
+- A disabled Module costs approximately nothing at runtime if its packages are never
+  imported, but the container is still shared.
+- A crash in one Module's first-party App can take down the others sharing that pod. This
+  is the price of seven containers instead of forty.
+
+### When to split a container
+
+Container count is a values decision, not an architectural fact. A pipeline stage can be
+run per Module when a Module earns it:
+
+```yaml
+svcAction:
+  replicaSets:
+    - name: svc-action-bot     ; modules: [bot]
+    - name: svc-action-social  ; modules: [social]
+```
+
+The pipeline stages are the natural split points because their scaling axes already
+differ; splitting *within* a stage by Module is the exception that needs evidence.
+
+Reach for this on evidence, not anticipation — a Module whose crashes are hurting others,
+or whose scaling profile genuinely diverges. Starting split is how the ~40 happened.
+
+Third-party Apps need none of this: they are always reached across a network boundary
+(`webhook_push` or `rest_pull` — see Apps), so vendor code never shares a process with ours
+regardless of topology.
 
 ## Open decisions
 
@@ -300,7 +440,7 @@ Detail lives in the companion plan. Summary:
 
 | Phase | Work | Gate to exit |
 |-------|------|--------------|
-| P0 | Extract Core; resolve the `services/` tree; **propagate tenant scoping into the Python fleet** | Core deploys alone; one tree only; cross-tenant isolation test passes after first being made to fail |
+| P0 | Extract Core; resolve the `services/` tree; **propagate tenant scoping into the Python fleet**; collapse to seven containers | Core deploys alone; one tree only; cross-tenant isolation test passes after first being made to fail |
 | P1 | App manifest, registry, binding resolution; rename to `app_installations`; convert 2–3 Bot units as proof | A community can rebind a Feature to a non-default App |
 | P2 | Bot — all triggers/actions/interactions become Apps | v2.2.x Bot parity, all as Apps |
 | P3 | Social — community, presence, RTC, browser-source as Apps | v2.2.x Social parity |
@@ -315,5 +455,7 @@ Detail lives in the companion plan. Summary:
 | Feature contracts churn after third-party Apps exist | Version interfaces from P1; never ship an unversioned contract |
 | The two trees (`action/` + `services/`) diverge further during migration | Resolve in P0, before any App conversion touches them |
 | "Lightweight CRM" expands under its own gravity | Customer's v3.0.0 scope is fixed at accounts/contacts/opportunities; anything more is 3.x |
-| Per-community App execution becomes an untrusted-code surface | Already true via `vendorExecutionService`; P1 must carry an explicit sandboxing decision |
-| Module count multiplies CI build time | Modules are sub-charts with path-filtered workflows, as `build-*.yml` already does |
+| Per-community App execution becomes an untrusted-code surface | Not in-process — `webhook_push`/`rest_pull` keep vendors across a network boundary. P1 must instead carry per-App egress allowlisting and timeout policy |
+| Seven shared containers widen blast radius vs. ~40 isolated ones | Accepted knowingly; pipeline stages are the split points when a Module earns one on evidence |
+| Consolidation loses per-module health signal | Each App reports its own health through the stage's health endpoint, not one liveness probe per Module |
+| CI rebuilds everything on any change | Seven images with path-filtered workflows, as `build-*.yml` already does per module |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -80,6 +80,11 @@ is scoped to the token's tenant **at the ORM layer** — never from a request bo
 parameter. Data containerization follows the same three levels, so a community's data is
 addressable only through its tenant.
 
+**Everything today lives in the default tenant, and continues to.** The default tenant is a
+tenant like any other, not a bypass — the same claim, the same middleware, the same key
+namespace. That is what keeps the migration non-breaking while preventing an untenanted code
+path surviving as a backdoor.
+
 ### Consequences for Features and Apps
 
 - A Feature contract declares the scopes it requires. An App implementing that Feature
@@ -344,14 +349,16 @@ The stages are joined by **Valkey Streams consumer groups**, not by synchronous 
 This is what makes the pipeline a pipeline rather than three services phoning each other:
 
 ```
-svc-ingest ──XADD──▶ waddles.ingest ──XREADGROUP──▶ svc-process
-                                                        │
-                                          XADD ─────────┘
-                                            ▼
-                                     waddles.action ──XREADGROUP──▶ svc-action
-                                                                        │
-                                          poison events ────XADD───▶ waddles.dlq
+svc-ingest ──XADD──▶ waddles:t:{tenant}:ingest ──XREADGROUP──▶ svc-process
+                                                                    │
+                                              XADD ────────────────┘
+                                                ▼
+                              waddles:t:{tenant}:action ──XREADGROUP──▶ svc-action
+                                                                            │
+                                  poison ────XADD───▶ waddles:t:{tenant}:dlq
 ```
+
+Streams are per tenant — see Tenant isolation below.
 
 What consumer groups buy, all of which the current point-to-point design lacks:
 
@@ -388,19 +395,66 @@ At-least-once delivery means **consumers must be idempotent**. Every event envel
 an id, and consumers dedupe on it. This is not optional — it is the cost of the redelivery
 guarantee above, and getting it wrong produces duplicate posts and double-charged actions.
 
-#### Naming and tenancy
+#### Tenant isolation inside Valkey
 
-One stream per stage, with module and tenant in the envelope rather than the stream name:
+Tenancy is a segment of the key, not a field in the payload. **Every key carries its tenant**,
+and the default tenant is simply one of them:
 
 ```
-waddles.ingest · waddles.process · waddles.action · waddles.dlq
+waddles:t:{tenant}:{concern}:...        keys, cache, sessions, rate limits
+waddles:t:{tenant}:{stage}              streams — ingest · process · action · dlq
 ```
 
-Stream-per-tenant would isolate noisy neighbours but multiplies stream count by the tenant
-roster, and Valkey consumer groups are per-stream. The tenant travels in the envelope and
-consumers scope on it — the same tenant claim P0 propagates through the Python fleet. A
-large tenant that genuinely needs isolation can be split onto its own stream later; that is
-a per-tenant escape hatch, not the default.
+Everything today lives in the default tenant and continues to, so the migration is a rename
+rather than a re-partition: `waddlebot:cache:*` becomes `waddles:t:default:cache:*`. The
+default tenant is not a special case in the code — it is a tenant like any other, which is
+what stops the untenanted path from surviving as a backdoor.
+
+**Streams are per tenant.** A shared stream would let every stage consumer read every
+tenant's events, which would defeat the key-level isolation entirely — the ACL below would
+guard the cache while the event path leaked. This supersedes a shared-stream design: the
+cost is real (see limits) but a transport that ignores the tenant boundary is not worth the
+saving.
+
+##### ACL users
+
+`docs/architecture/redis-architecture.md` already specifies per-service ACL users
+(`cache_user`, `ratelimit_user`, `queue_user`) with key-prefix patterns. It is marked
+"Advanced - Optional" and implemented nowhere. v3 implements it and composes it with
+tenancy — a user per **(tenant, stage)**:
+
+```
+ACL SETUSER waddles-t-{tenant}-ingest on >{secret} \
+    ~waddles:t:{tenant}:* +@read +@write +@stream -@dangerous
+```
+
+Stages are few, so user count is tenants × ~4 rather than tenants × services. Credentials
+live in `credential_manager_module` and rotate there.
+
+**What this actually buys**, stated precisely so it is not oversold: a stage container still
+holds credentials for every tenant it serves, so this is not a containment boundary against
+a compromised stage. What it is, is **defense in depth against our own bugs** — a connection
+authenticated as tenant A cannot read tenant B's keys, so a tenant-scoping mistake surfaces
+as a Valkey `NOPERM` error instead of a silent cross-tenant read. That is the exact
+datastore-level mirror of the ORM-layer tenant scoping in P0, and the two fail independently.
+
+##### Limits, and where this stops working
+
+Per-tenant separation has a cost that scales with the tenant roster:
+
+| Quantity | Grows as |
+|----------|----------|
+| Streams | tenants × 4 stages |
+| ACL users | tenants × 4 stages |
+| Connections | tenants × stages × replicas |
+
+Connections are the binding constraint. Pool per tenant with idle eviction, and keep an
+active-tenant set so a stage maintains readers only for tenants with traffic. This holds
+comfortably into the hundreds of tenants and needs revisiting in the low thousands.
+
+The escape hatch at that point is not to abandon isolation but to shard it: Valkey Cluster
+with per-tenant hash tags, or a dedicated Valkey for a large tenant. Dedicated infrastructure
+per tenant also maps naturally onto the Enterprise tier if it becomes a commercial line.
 
 #### What exists today
 
@@ -550,4 +604,6 @@ Detail lives in the companion plan. Summary:
 | Consolidation loses per-module health signal | Each App reports its own health through the stage's health endpoint, not one liveness probe per Module |
 | Streams add an at-least-once duplicate-delivery failure mode the current synchronous calls do not have | Envelope ids and consumer-side dedupe are mandatory from P0, with a redelivery test that has been made to fail |
 | Valkey becomes a single point of failure for the whole event path | It already is for cache and sessions; P0 sizes it for stream retention and configures persistence deliberately rather than inheriting cache defaults |
+| Per-tenant streams and ACL users grow linearly with the tenant roster | Pool per tenant with idle eviction and an active-tenant set; revisit in the low thousands, then shard via Cluster hash tags or dedicated Valkey rather than dropping isolation |
+| A "missing tenant means default" fallback outlives the migration and becomes a bypass | The fallback has a recorded cutoff date, after which unclaimed tokens are rejected |
 | CI rebuilds everything on any change | Seven images with path-filtered workflows, as `build-*.yml` already does per module |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -141,9 +141,14 @@ environment instead of forty.
 
 ### Two deployment modes, one values flip apart
 
-SkausWatch already ships `skauswatch-spire` — a nested SPIFFE/SPIRE trust authority for the
-single `penguintech.io` trust domain, root plus per-cluster child servers. v3 adopts its
-topology rather than inventing one:
+SkausWatch is itself a modular platform, and its **authentication module** provides this —
+`skauswatch-auth` (JWT claims and scope authz), `skauswatch-identity` (SPIFFE Workload API),
+`skauswatch-spire-entry`, plus the `spire`, `pki`, `sshca` and `vault` charts. The
+`skauswatch-spire` chart is a nested SPIFFE/SPIRE trust authority for the single
+`penguintech.io` trust domain: root plus per-cluster child servers.
+
+That module has already solved this problem in Rust. Waddles is Python, so it mirrors the
+shape rather than reusing the crates:
 
 | Mode | Configuration | When |
 |------|---------------|------|
@@ -168,6 +173,22 @@ SPIFFE is one of three identity mechanisms here, and they answer different quest
 An SVID does not carry tenancy, so it complements the per-tenant ACL users rather than
 replacing them. A compromised stage still authenticates as itself; what the tenant ACL
 constrains is which keys it can reach.
+
+#### Holding an SVID is not checking one
+
+`skauswatch-identity` splits this into two responsibilities, and the second is the one easy
+to omit:
+
+- `IdentityProvider` attests to the local Workload API socket (`SPIFFE_ENDPOINT_SOCKET`),
+  holds the X.509-SVID and trust bundle set, and builds mTLS configs from them.
+- `SpiffeIdMatcher` is a **caller-supplied allowlist enforced against the peer's SPIFFE ID**,
+  and is what admits federated trust domains.
+
+Presenting an identity and verifying the other end's are different things. Without the
+matcher, mTLS proves only that the peer holds *some* valid SVID in the trust domain — every
+workload in the mesh would pass. Each of the seven services declares which peer SPIFFE IDs
+it accepts; `svc-core` accepting calls from the three stages is not the same as accepting
+calls from anything holding a `penguintech.io` SVID.
 
 Per `security.md`, mTLS does **not** remove the JWT requirement: every inter-service call
 carries a short-lived signed JWT regardless of transport, whether or not SPIFFE is live for
@@ -278,6 +299,26 @@ A Feature is available to a tenant when **both** hold:
 
 New flags default OFF. If either the license server or PostHog is unreachable, fall back
 to the last-known cached value; never crash, and never fail open on a never-seen flag.
+
+#### Middleware ordering is a contract, not a preference
+
+`skauswatch-auth` states it explicitly, and v3 adopts the same ordering:
+
+```
+tenant check  →  scope check  →  feature / licensing check
+```
+
+The order is load-bearing in both directions:
+
+- **Tenant before scope.** A scope check against an unverified tenant answers the wrong
+  question — it establishes what the caller may do, without establishing whose data they are
+  doing it to. `security.md` requires tenant middleware to run first for exactly this reason.
+- **Scope before feature.** A feature gate consulted before authorization leaks entitlement
+  information to callers who have no business asking, and burns a licensing round-trip on
+  requests that were going to 403 anyway.
+
+Authorization decisions use `scope` only. `roles` is informational and audit-only and is
+never branched on — roles are bundles expanded into scopes at token issuance.
 
 This mirrors the WaddleAI product definition in `license-server` — see
 `api/app/seeds/waddleai.py`, where each feature carries `tier_requirements` per tier plus
@@ -670,4 +711,6 @@ Detail lives in the companion plan. Summary:
 | A "missing tenant means default" fallback outlives the migration and becomes a bypass | The fallback has a recorded cutoff date, after which unclaimed tokens are rejected |
 | SPIRE deployed standalone, then federation with SkausWatch needs a topology change | Deploy as `child` with the upstream disabled from the start; promotion is a values flip plus a join token |
 | mTLS is treated as replacing the inter-service JWT | `security.md` requires both regardless of transport; the SVID-required test does not assert the JWT, so both need their own gate |
+| mTLS is enabled without a peer SPIFFE ID allowlist, so any workload in the trust domain is accepted | Per-service accepted-peer lists, with a test asserting a valid-but-unlisted SVID is rejected |
+| Middleware layers get reordered during refactoring, and the happy path still passes | The ordering contract has its own test that reverses the layers and confirms the reversal is caught |
 | CI rebuilds everything on any change | Seven images with path-filtered workflows, as `build-*.yml` already does per module |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -1,0 +1,319 @@
+# v3.0.x SCBM Module + App Architecture Design
+
+**Date:** 2026-08-26
+**Status:** Draft
+**Branch:** docs/v3-scbm-architecture
+
+## Goal
+
+Restructure Waddles from a flat collection of ~40 co-equal service containers into a
+layered platform: a mandatory **Core**, four globally-toggleable **Modules** (Social,
+Customer, Bot, Marketing), **Features** that Modules group, and **Apps** that implement
+those Features and can be swapped per tenant or per community through the marketplace.
+
+The model is Nextcloud's: a core platform plus an app store, where the shipped defaults
+are themselves apps. Nothing is a privileged built-in, because a built-in that cannot be
+replaced makes the extension point decorative.
+
+v3.0.0 ships **feature parity with v2.2.x** — Social and Bot fully populated — plus
+lightweight Customer and Marketing. It does not attempt a complete CRM or a full
+conferencing suite; those are 3.x work with their own specs.
+
+## Hierarchy
+
+```
+Core / shared services      identity · event bus · marketplace · tenancy · workflow
+        │                   always on, every deployment
+        ▼
+Module                      Social · Customer · Bot · Marketing
+        │                   ON/OFF GLOBALLY (cluster-wide) — the key differentiator
+        ▼
+Feature                     social.polls · bot.shoutout · customer.pipeline
+        │                   a versioned contract; gated by license tier AND PostHog flag
+        ▼
+App                         first-party default │ marketplace alternative
+                            the implementation; bound per tenant and/or community
+```
+
+The scoping ladder narrows at each level, and each level uses a different mechanism:
+
+| Level | Enable/disable scope | Mechanism | Who decides |
+|-------|---------------------|-----------|-------------|
+| Core | always on | mandatory dependency | nobody — it is not optional |
+| Module | global / cluster-wide | Helm `enabled:` + global toggle | cluster operator |
+| Feature | per tenant | license tier × PostHog flag | licensing + rollout |
+| App | per tenant and/or community | marketplace binding | tenant admin / community admin |
+
+A Module is either deployed or it is not. There is deliberately no per-tenant Module
+toggle: that would mean running Social's services while denying them to a tenant, paying
+the operational cost of a Module nobody can reach. Per-tenant variation belongs one level
+down, at Features.
+
+## Identity and data scoping
+
+Identity, authorization, and data containerization all follow one ladder:
+
+```
+global  →  tenant  →  community
+                      (surfaces as "team" or "org" in some Modules)
+```
+
+Each level carries its own scopes. **Roles are bundles of scopes at a level**, expanded at
+token issuance; middleware checks scopes only, never role names. Narrower levels restrict
+what a broader level granted — they never expand it.
+
+| Level | Boundary | Example scopes |
+|-------|----------|----------------|
+| Global | the platform | `*:admin`, `platform:read` |
+| Tenant | the customer; always present on every token | `community:create`, `billing:read` |
+| Community | a team/org inside a tenant | `social.polls:write`, `bot.command:admin` |
+
+Per `security.md`: every token carries a `tenant` claim, tenant middleware runs *before*
+scope checks, a mismatch is an immediate 403, and every query, cache key and service call
+is scoped to the token's tenant **at the ORM layer** — never from a request body or
+parameter. Data containerization follows the same three levels, so a community's data is
+addressable only through its tenant.
+
+### Consequences for Features and Apps
+
+- A Feature contract declares the scopes it requires. An App implementing that Feature
+  **inherits those scopes and cannot widen them** — installing a third-party App must never
+  be a privilege-escalation path.
+- Third-party App execution is already tenant-scoped through the marketplace; per-community
+  binding narrows it further, and the executing identity is the community's, not the
+  vendor's.
+
+### What exists today
+
+The ladder is **half-built**, and the half that is missing is the enforcing half:
+
+| Piece | State |
+|-------|-------|
+| `tenants`, `tenant_admins`, `tenant_settings` tables | exist |
+| `communities.tenant_id` FK | exists |
+| Hub (Node) tenant resolution + `is_global` | exists — `middleware/auth.js` sets `req.tenant` |
+| Python service fleet | **tenant-blind** — 246 files query by `community_id` with no tenant filter |
+| Roles as per-level scope bundles | **not implemented** — `flask_core.setup_default_roles` defines four global roles, and `admin` holds `['*']` |
+
+The Python services reach communities directly by `community_id` without checking that the
+community belongs to the caller's tenant. `security.md` names the equivalent pattern as
+forbidden: a query without a tenant filter in a multi-tenant system is a tenant-isolation
+hole regardless of whether the id arrives in a body, a param, or a path.
+
+Closing this is P0 work and the largest single item in it — 246 files plus a middleware
+layer plus the role model. It is not v3 scope creep; every Feature and App gating decision
+downstream assumes a trustworthy tenant claim, so nothing above it is sound until it lands.
+
+### This ladder is parallel to App binding, not the same as it
+
+Identity has a **global** level. App binding deliberately does not — the shipped default
+App is code, not a bindable row, so there is no cluster-wide replacement. An operator can
+hold global admin scope and still not swap a community's App platform-wide.
+
+The two ladders look alike and must not be collapsed into one mechanism: one answers *who
+may act on what*, the other answers *which implementation serves this slot here*.
+
+## Vocabulary
+
+The word "module" currently means three different things in this repo, which is why the
+existing `services/` consolidation is hard to reason about:
+
+- a deployable container — `core/identity_core_module/`
+- a marketplace-installable unit — `hub_module_installations.module_id`
+- a Python package — `action/interactive/*_module/`
+
+v3 splits these:
+
+| Term | Means | Example |
+|------|-------|---------|
+| **Core** | the mandatory platform | identity, event bus, marketplace |
+| **Module** | one of four product surfaces, a grouping of Features | Social, Customer, Bot, Marketing |
+| **Feature** | a versioned capability contract inside a Module | `bot.shoutout`, `social.polls` |
+| **App** | an implementation of a Feature, installable and bindable | `shoutout-default`, `acme-shoutout-pro` |
+| **Service** | a deployable container | `social-api`, `bot-router` |
+
+Renaming `hub_module_installations` to `app_installations` is part of P1. The existing
+column meaning does not change; only the name stops lying.
+
+## Core
+
+Core is everything two or more Modules need. That is the whole test — if a second Module
+needs it, it belongs in Core, and if only one does, it does not.
+
+| Core service | Seeded from | Responsibility |
+|--------------|-------------|----------------|
+| identity | `core/identity_core_module` | OIDC/JWT, tenant claim, scopes |
+| security | `core/security_core_module` | authz enforcement, audit |
+| credentials | `core/credential_manager_module` | per-tenant secret custody |
+| tenancy | `core/community_module` | tenants, communities, membership |
+| event bus | **split from** `processing/router_module` | pub/sub spine all Modules emit to |
+| workflow | `core/workflow_core_module` | cross-Module automation |
+| analytics | `core/analytics_core_module` | shared telemetry sink |
+| marketplace | `admin/marketplace_module` | catalog, vendors, subscriptions, App installs + bindings |
+| hub | `admin/hub_module` | admin shell that mounts enabled Modules |
+| entitlement client | new, wraps `penguin-licensing` + PostHog | the Feature gate |
+
+### The router split
+
+`processing/router_module` today mixes two concerns: generic event routing, and
+Twitch/Discord command semantics (command registry, cooldowns, emote handling).
+
+The generic half becomes the Core **event bus**. The command half stays in Bot. Without
+this split, Social, Customer and Marketing would each have to depend on Bot to emit an
+event — which would make the Modules interdependent and defeat global toggling.
+
+## Modules
+
+Modules never import each other. Cross-Module behaviour goes through the Core event bus.
+This is what makes "deploy Bot only" or "Social + Customer" a values-file decision rather
+than a fork.
+
+| Module | Scope | Seeded from | Green-field share |
+|--------|-------|-------------|-------------------|
+| **Bot** | triggers, actions, interactions, command dispatch | `trigger/receiver/*`, `action/pushing/*`, `action/interactive/*` | ~0% — this is v2.2.x |
+| **Social** | chat, presence, communities, voice/video, browser sources | `community_module`, `presence`, `alias`, `quote`, `shoutout`, `module_rtc`, `video_proxy`, `browser_source_core` | ~50% |
+| **Marketing** | scheduling, publishing, cross-platform analytics | `engagement_module`, part of `analytics_core` | ~70% |
+| **Customer** | accounts, contacts, opportunities, pipelines, cases | nothing | ~100% |
+
+Social's ambition (replace Slack/Discord *and* Zoom/Teams) and Customer's (SuiteCRM/Odoo
+class) are each multi-year products. This design covers how they plug in, not what they
+contain. Each gets its own spec.
+
+## Features
+
+A Feature is a **contract**, not code. It declares:
+
+- a stable id — `social.polls`
+- a versioned interface — the API an App must satisfy
+- the Core capabilities an implementing App may use
+- the minimum license tier
+- a PostHog flag key — `waddles.social.polls`
+
+Because a community can swap in a third-party App, the Feature interface is the load-
+bearing boundary in this architecture — more so than Module boundaries, which are only
+deployment groupings. Feature interfaces get semantic versioning and a deprecation window;
+Module boundaries do not need one.
+
+### Gating
+
+A Feature is available to a tenant when **both** hold:
+
+1. the tenant's license tier entitles it, and
+2. its PostHog flag evaluates true for that tenant.
+
+New flags default OFF. If either the license server or PostHog is unreachable, fall back
+to the last-known cached value; never crash, and never fail open on a never-seen flag.
+
+This mirrors the WaddleAI product definition in `license-server` — see
+`api/app/seeds/waddleai.py`, where each feature carries `tier_requirements` per tier plus
+`default_entitled`. v3 adds `api/app/seeds/waddles.py` in the same shape.
+
+## Apps
+
+An App implements one or more Features. **First-party defaults are Apps too** — shipping in
+the box is a default *binding*, not a different kind of code. This is the only way the
+extension point is real rather than nominal.
+
+### Manifest
+
+```yaml
+id: shoutout-default
+module: bot
+provides: [bot.shoutout@1]      # Feature contracts, versioned
+requires_core: [identity, event-bus, tenancy]
+min_tier: free
+flag: waddles.bot.shoutout
+vendor: penguintech             # first-party
+```
+
+### Binding resolution
+
+Narrowest scope wins:
+
+```
+community binding  →  tenant binding  →  shipped default App
+```
+
+Two Apps claiming the same Feature is not a conflict; the binding at that scope picks one.
+The first-party App remains a permanent fallback and **cannot be swapped cluster-wide** —
+there is deliberately no platform-scope binding. That guarantees every deployment has a
+known-good baseline to compare against when a third-party App misbehaves, which is what
+makes support tractable.
+
+### Two entitlement systems
+
+These are separate and both already half-exist:
+
+| | First-party Feature | Third-party App |
+|---|---|---|
+| Gate | license tier + PostHog flag | marketplace subscription |
+| Lives in | `license-server` `tier_requirements` | `marketplace_module` `subscriptionController` |
+| Scope | per tenant | per tenant/community install |
+
+A third-party App may implement a Feature the tenant's tier does not entitle. The Feature
+gate wins: buying an App does not buy the Feature slot it plugs into.
+
+### What already exists
+
+More of this is built than the naming suggests:
+
+- `hub_module_installations (community_id, module_id)` is the App-installation table.
+- `routerIntegrationController.getCommunityCommands(communityId)` already resolves
+  per-community marketplace units at runtime.
+- `vendorExecutionService.executeCommand()` already executes third-party code.
+
+v3 generalises this from "commands" to Feature contracts, and inserts the **tenant** scope
+between community and default.
+
+## Deployment
+
+Each Module is a Helm sub-chart with an `enabled:` condition, defaulting off except Core.
+Turning a Module off removes its services entirely rather than leaving them running behind
+a flag — an unreachable Module should cost nothing.
+
+```yaml
+core:      { enabled: true }   # not overridable
+modules:
+  bot:       { enabled: true }
+  social:    { enabled: true }
+  customer:  { enabled: false }
+  marketing: { enabled: false }
+```
+
+## Open decisions
+
+These need a call before the phases they block:
+
+1. **`core/module_rtc` is Go.** It is the seed of Social's conferencing story — precisely
+   where it would need to grow, which the Go phase-out rule says it should not. Rewrite in
+   Rust during P3, or grant a documented exception. Blocks P3.
+2. **The `services/` tree is a half-finished consolidation** with documented orphaned
+   duplicates (`docs/MODULE_CANONICAL_SOURCES.md`). v3 either completes it or deletes it;
+   keeping both trees is what produced the divergence. Blocks P0.
+3. **Tier mapping is not yet set.** Which Features land in Free vs Professional vs
+   Enterprise is a commercial decision, not an architectural one. Blocks the
+   `seeds/waddles.py` definition in P1.
+
+## Migration phases
+
+Detail lives in the companion plan. Summary:
+
+| Phase | Work | Gate to exit |
+|-------|------|--------------|
+| P0 | Extract Core; resolve the `services/` tree; **propagate tenant scoping into the Python fleet** | Core deploys alone; one tree only; cross-tenant isolation test passes after first being made to fail |
+| P1 | App manifest, registry, binding resolution; rename to `app_installations`; convert 2–3 Bot units as proof | A community can rebind a Feature to a non-default App |
+| P2 | Bot — all triggers/actions/interactions become Apps | v2.2.x Bot parity, all as Apps |
+| P3 | Social — community, presence, RTC, browser-source as Apps | v2.2.x Social parity |
+| P4 | Customer + Marketing lightweight Apps | accounts/contacts/opportunities; scheduling + analytics |
+| P5 | Cut v3.0.0 | parity verified against v2.2.x |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Tenant scoping lands late, so Feature/App gating is built on an untrustworthy claim | It is P0, before any App conversion; nothing above it is sound until it passes |
+| Feature contracts churn after third-party Apps exist | Version interfaces from P1; never ship an unversioned contract |
+| The two trees (`action/` + `services/`) diverge further during migration | Resolve in P0, before any App conversion touches them |
+| "Lightweight CRM" expands under its own gravity | Customer's v3.0.0 scope is fixed at accounts/contacts/opportunities; anything more is 3.x |
+| Per-community App execution becomes an untrusted-code surface | Already true via `vendorExecutionService`; P1 must carry an explicit sandboxing decision |
+| Module count multiplies CI build time | Modules are sub-charts with path-filtered workflows, as `build-*.yml` already does |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -23,6 +23,34 @@ v3.0.0 ships **feature parity with v2.2.x** — Social and Bot fully populated �
 lightweight Customer and Marketing. It does not attempt a complete CRM or a full
 conferencing suite; those are 3.x work with their own specs.
 
+## Reuse is the default; rewriting needs a reason
+
+v2.2.x is not a first draft to be replaced. It is a working system carrying years of fixes
+that are invisible until they are missing — healthcheck timings that were tuned after a
+flapping probe, `securityContext` blocks that were added after a rootless failure, retry and
+backoff values that came from a real outage, the `grpc.aio` patterns, hash-pinned lockfiles,
+digest-pinned images.
+
+**A restructure is the most efficient possible way to lose all of it**, because nothing fails
+when a tuned value is replaced by a plausible default. The regression appears weeks later and
+looks unrelated.
+
+So the standing rule for every phase:
+
+- **Move code, do not retype it.** A file that lands in a new place should arrive by `git mv`
+  or copy, then be edited — not rewritten from its docstring.
+- **Rewriting is a decision that gets stated.** "Reuse" needs no justification; "rewrite"
+  needs one in the PR description. `module_rtc` has one (Go phase-out). Most things will not.
+- **Port the operational details explicitly.** Health checks, `securityContext`, resource
+  limits, image digests, timeouts and retry policy are carried across as a checklist item, not
+  as an afterthought — they encode fixes whose original bug reports are long gone.
+- **Where v2.2.x is already correct, v3 inherits it unchanged**, including things this design
+  did not think to mention.
+
+The corollary matters too: where v2.2.x is *wrong*, fix it there rather than carrying the
+defect into v3 behind a migration. The consent-persistence defect in Compliance is an example
+— it is a live bug today, and v3 is not a reason to leave it.
+
 ## Hierarchy
 
 ```
@@ -745,20 +773,46 @@ AI Act scope. Two consequences that touch the design rather than the policy:
   assume it might — meaning logged inputs, an explanation path, and human review — because
   retrofitting explainability into a scoring system is far harder than designing for it.
 
-### Webui obligations
+### Webui obligations — most of this already exists
 
-The webui carries most of the visible surface:
+`hub-webui` already carries the machinery, and v3 **carries it forward rather than rebuilding
+it**:
 
-| Requirement | Source | Shape |
-|---|---|---|
-| Consent before non-essential cookies, granular by category, refusable as easily as accepted | GDPR/ePrivacy | consent gate in `hub-webui`; nothing non-essential initialises before it |
-| "Do Not Sell or Share My Personal Information" | CCPA/CPRA | opt-out link and a respected Global Privacy Control signal |
-| Access, deletion, correction, portability | GDPR + CCPA/CPRA | self-service DSAR flows, not a support ticket |
-| AI interaction disclosure | EU AI Act | visible marker wherever AI generates or scores |
+| Piece | State |
+|---|---|
+| Cookie banner, preferences modal, cookie policy page | built — `CookieBanner.jsx`, `CookiePreferencesModal.jsx`, `CookiePolicy.jsx` |
+| Consent context + hook | built — `CookieConsentContext.jsx`, `useCookieConsent.js` |
+| Server-side consent record with versioning, expiry, `requiresUpdate` | built — `cookieConsentService.js` |
+| Four categories: necessary / functional / analytics / marketing | built, correct granularity |
+| Erasure | built — `dataPrivacyController.requestDataDeletion` |
+| Access, correction, portability | **missing** — `dataPrivacyController` exports deletion only |
+| CCPA/CPRA "Do Not Sell or Share", Global Privacy Control | **missing** |
+| Analytics actually gated on the `analytics` consent | **not wired** |
 
-Consent state is per **user**, and users belong to communities within tenants — so consent
-records follow the same `global → tenant → community` scoping as everything else, and land in
-whichever regional deployment holds that user.
+#### A verified defect to fix before carrying it forward
+
+Consent is **never persisted server-side**, and the failure is silent. Two independent faults
+stack:
+
+1. **Body shape.** `CookieConsentContext.jsx` posts the consent object directly —
+   `api.post('/api/v1/cookie', newConsent)` — while `cookieConsentController` destructures
+   `const { preferences } = req.body` and rejects a missing `preferences` with a 400. Every
+   save request therefore fails.
+2. **Key names.** Even wrapped correctly it would not work: the frontend sends
+   `analytics_cookies` / `functional_cookies` / `marketing_cookies`, the backend reads
+   `preferences.analytics` / `.functional` / `.marketing`. `Boolean(undefined)` is `false`, so
+   every choice would record as denied.
+
+The 400 is swallowed by `console.debug('Could not save consent to API:', ...)`, so the banner
+looks like it works. Consent lives only in `localStorage`.
+
+That matters beyond tidiness: GDPR Art. 7(1) requires being able to **demonstrate** that a
+subject consented, and a record that was never written cannot demonstrate anything. It is also
+the exact silent-failure shape this project's own standards call out — a `catch` that logs at
+debug and continues.
+
+Fix it in v2.2.x rather than carrying it into v3; it is a live defect today, not a migration
+concern.
 
 ### What already helps
 
@@ -1140,6 +1194,7 @@ Detail lives in the companion plan. Summary:
 | A consent banner blocks nothing because the analytics SDK initialised early to fetch feature flags | Flags resolve server-side for the webui; verified by loading with consent refused and asserting no analytics request |
 | Personal data accumulates in append-only streams with no retention bound and no erasure path | Bounded `MAXLEN`/`MINID` per stream, and envelopes carry UUIDs only, enforced by a field allowlist |
 | Third-party Apps receive user data without the community knowing what they receive | Install-time disclosure recorded against the community, plus the tenant-scoped egress allowlist as the enforcement point |
+| The restructure silently drops tuned healthcheck timings, securityContext blocks and retry values | Reuse is the default and rewriting is a stated decision; operational details are ported as an explicit checklist, not re-derived |
 | SPIRE deployed standalone, then federation with SkausWatch needs a topology change | Deploy as `child` with the upstream disabled from the start; promotion is a values flip plus a join token |
 | mTLS is treated as replacing the inter-service JWT | `security.md` requires both regardless of transport; the SVID-required test does not assert the JWT, so both need their own gate |
 | mTLS is enabled without a peer SPIFFE ID allowlist, so any workload in the trust domain is accepted | Per-service accepted-peer lists, with a test asserting a valid-but-unlisted SVID is rejected |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -152,7 +152,7 @@ needs it, it belongs in Core, and if only one does, it does not.
 | security | `core/security_core_module` | authz enforcement, audit |
 | credentials | `core/credential_manager_module` | per-tenant secret custody |
 | tenancy | `core/community_module` | tenants, communities, membership |
-| event bus | **split from** `processing/router_module` | pub/sub spine all Modules emit to |
+| event bus | `flask_core.stream_pipeline`, consolidated | **a shared library over Valkey Streams, not a service** — see Transport |
 | workflow | `core/workflow_core_module` | cross-Module automation |
 | analytics | `core/analytics_core_module` | shared telemetry sink |
 | marketplace | `admin/marketplace_module` | catalog, vendors, subscriptions, App installs + bindings |
@@ -164,9 +164,15 @@ needs it, it belongs in Core, and if only one does, it does not.
 `processing/router_module` today mixes two concerns: generic event routing, and
 Twitch/Discord command semantics (command registry, cooldowns, emote handling).
 
-The generic half becomes the Core **event bus**. The command half stays in Bot. Without
-this split, Social, Customer and Marketing would each have to depend on Bot to emit an
-event — which would make the Modules interdependent and defeat global toggling.
+The generic half becomes the Core **event bus** — which is a *library*, not a service. It is
+the consolidated `StreamPipeline` that every stage links against to publish and consume on
+Valkey Streams. Putting a gRPC service in front of Valkey would add a hop and a failure
+domain to buy nothing; the stream broker is already the shared component.
+
+The command half stays in Bot, as a consumer of `waddles.process`.
+
+Without this split, Social, Customer and Marketing would each have to depend on Bot to emit
+an event — which would make the Modules interdependent and defeat global toggling.
 
 ## Modules
 
@@ -332,6 +338,90 @@ for whether a future split is justified:
 | `svc-process` | Core event bus, routing, Bot command dispatch, workflow | event volume |
 | `svc-action` | outbound actions, interaction Apps, third-party App calls | outbound throughput and remote latency |
 
+### Transport between stages: Valkey Streams
+
+The stages are joined by **Valkey Streams consumer groups**, not by synchronous calls.
+This is what makes the pipeline a pipeline rather than three services phoning each other:
+
+```
+svc-ingest ──XADD──▶ waddles.ingest ──XREADGROUP──▶ svc-process
+                                                        │
+                                          XADD ─────────┘
+                                            ▼
+                                     waddles.action ──XREADGROUP──▶ svc-action
+                                                                        │
+                                          poison events ────XADD───▶ waddles.dlq
+```
+
+What consumer groups buy, all of which the current point-to-point design lacks:
+
+| Property | Consequence |
+|----------|-------------|
+| Backpressure | a slow `svc-action` queues rather than timing out `svc-ingest` |
+| At-least-once + ack | a crashed consumer's in-flight events are redelivered, not lost |
+| Horizontal scale per stage | replicas join one group and split the partition — this is *why* stages scale independently |
+| Replay | a stream is a log; a bad deploy can be reprocessed from an offset |
+| DLQ | poison events are parked, not retried forever |
+
+#### Most of the gRPC mesh disappears
+
+The existing gRPC surface — 21 client call sites, a port registry, per-module `.proto`
+files — exists because two dozen containers had to talk to each other. It is a *symptom* of
+the container sprawl, not an independent design choice, and collapsing to seven removes
+most of what it was solving:
+
+| Call shape today | After consolidation |
+|------------------|---------------------|
+| module → module inside the same stage | **an in-process function call** — no network, no proto, no port |
+| stage → stage (event path) | a Valkey Stream |
+| stage → `svc-core` (entitlement, identity) | **stays gRPC** — genuinely cross-container and synchronous |
+
+`backend.md` mandates gRPC for service-to-service communication, and that still holds for
+the third row. The first row simply stops being service-to-service, so the mandate no longer
+applies to it — this is a reduction in surface, not an exception to the rule.
+
+The rule of thumb for what remains: if the caller does not need the result to continue, it
+belongs on a stream; if it does and the callee is in another container, gRPC; if it does and
+the callee is in the same container, call it.
+
+At-least-once delivery means **consumers must be idempotent**. Every event envelope carries
+an id, and consumers dedupe on it. This is not optional — it is the cost of the redelivery
+guarantee above, and getting it wrong produces duplicate posts and double-charged actions.
+
+#### Naming and tenancy
+
+One stream per stage, with module and tenant in the envelope rather than the stream name:
+
+```
+waddles.ingest · waddles.process · waddles.action · waddles.dlq
+```
+
+Stream-per-tenant would isolate noisy neighbours but multiplies stream count by the tenant
+roster, and Valkey consumer groups are per-stream. The tenant travels in the envelope and
+consumers scope on it — the same tenant claim P0 propagates through the Python fleet. A
+large tenant that genuinely needs isolation can be split onto its own stream later; that is
+a per-tenant escape hatch, not the default.
+
+#### What exists today
+
+`flask_core.stream_pipeline.StreamPipeline` already implements this — `XADD`,
+`XREADGROUP`, `XGROUP CREATE`, acking, and a DLQ. It is used by **exactly one service**
+(`processing/router_module`), behind an off-by-default flag. There is also a second,
+overlapping implementation in `flask_core.message_queue.MessageQueue`.
+
+So the capability is built and unused. v3's work is adoption and consolidation, not
+invention: pick one abstraction, delete the other, and make it the default path between
+stages rather than an opt-in extra.
+
+The infrastructure is also still Redis, and Alpine, and unpinned. Eight manifest entries
+break the base-image rules — `redis:7-alpine` (4) and `postgres:15/16-alpine` (4) — against
+three standing requirements: Valkey over Redis, Debian bookworm over Alpine, and SHA256
+digest pinning. Postgres is also split across two majors (15 and 16) with no digest on any
+of them.
+
+Correcting all eight to `valkey/valkey:8-bookworm@sha256:<digest>` and
+`postgres:17-bookworm@sha256:<digest>` is P0 work.
+
 ### Modules cut across stages
 
 A Module is a **vertical**; the pipeline is **horizontal**. A Module is not assigned to a
@@ -440,7 +530,7 @@ Detail lives in the companion plan. Summary:
 
 | Phase | Work | Gate to exit |
 |-------|------|--------------|
-| P0 | Extract Core; resolve the `services/` tree; **propagate tenant scoping into the Python fleet**; collapse to seven containers | Core deploys alone; one tree only; cross-tenant isolation test passes after first being made to fail |
+| P0 | Extract Core; resolve the `services/` tree; **propagate tenant scoping into the Python fleet**; Valkey + Streams as the stage transport; collapse to seven containers | One tree only; cross-tenant isolation, redelivery, DLQ and idempotency tests all pass after first being made to fail; zero Alpine or unpinned images; gRPC call sites classified with counts |
 | P1 | App manifest, registry, binding resolution; rename to `app_installations`; convert 2–3 Bot units as proof | A community can rebind a Feature to a non-default App |
 | P2 | Bot — all triggers/actions/interactions become Apps | v2.2.x Bot parity, all as Apps |
 | P3 | Social — community, presence, RTC, browser-source as Apps | v2.2.x Social parity |
@@ -458,4 +548,6 @@ Detail lives in the companion plan. Summary:
 | Per-community App execution becomes an untrusted-code surface | Not in-process — `webhook_push`/`rest_pull` keep vendors across a network boundary. P1 must instead carry per-App egress allowlisting and timeout policy |
 | Seven shared containers widen blast radius vs. ~40 isolated ones | Accepted knowingly; pipeline stages are the split points when a Module earns one on evidence |
 | Consolidation loses per-module health signal | Each App reports its own health through the stage's health endpoint, not one liveness probe per Module |
+| Streams add an at-least-once duplicate-delivery failure mode the current synchronous calls do not have | Envelope ids and consumer-side dedupe are mandatory from P0, with a redelivery test that has been made to fail |
+| Valkey becomes a single point of failure for the whole event path | It already is for cache and sessions; P0 sizes it for stream retention and configures persistence deliberately rather than inheriting cache defaults |
 | CI rebuilds everything on any change | Seven images with path-filtered workflows, as `build-*.yml` already does per module |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -85,6 +85,15 @@ tenant like any other, not a bypass — the same claim, the same middleware, the
 namespace. That is what keeps the migration non-breaking while preventing an untenanted code
 path surviving as a backdoor.
 
+It is also the **permanent** shape for most deployments, not a migration artifact: Free and
+Professional are both capped at the single default tenant, and only Enterprise is
+multi-tenant. That cuts both ways and is worth being deliberate about:
+
+- The single-tenant path is the *common* path, so it must not be the slow or awkward one.
+- The multi-tenant path is exercised only by Enterprise deployments, so it will rot unless
+  the single-tenant case runs the identical code with N=1. A `if tenant == "default": ...`
+  shortcut would leave the multi-tenant branch effectively untested in most environments.
+
 ### Consequences for Features and Apps
 
 - A Feature contract declares the scopes it requires. An App implementing that Feature
@@ -551,6 +560,11 @@ Connections are the binding constraint. Pool per tenant with idle eviction, and 
 active-tenant set so a stage maintains readers only for tenants with traffic. This holds
 comfortably into the hundreds of tenants and needs revisiting in the low thousands.
 
+**In practice this curve only applies to Enterprise.** Free and Professional are capped at the
+single default tenant, so their multipliers are all 1 — four streams, four ACL users, one
+connection pool. The isolation machinery is built for Enterprise and exercised everywhere at
+N=1, which is exactly the property that keeps the multi-tenant path from rotting.
+
 The escape hatch at that point is not to abandon isolation but to shard it: Valkey Cluster
 with per-tenant hash tags, or a dedicated Valkey for a large tenant. Dedicated infrastructure
 per tenant also maps naturally onto the Enterprise tier if it becomes a commercial line.
@@ -765,6 +779,7 @@ its source; rows sourced from "this design" are proposals, not standards.
 | Customer: accounts, contacts, opportunities | Free | lightweight by v3.0.0 scope |
 | Marketing: manual posting | Free | lightweight by v3.0.0 scope |
 | More than one admin | Professional | `critical-rules.md` — Free is capped at 1 admin |
+| **More than one tenant** | **Enterprise** | Free and Professional are both capped at the single default tenant; matches WaddleAI, where multi-tenancy is Enterprise |
 | Whitelabelling | Professional | `critical-rules.md` |
 | Google OAuth2 SSO | Professional | `critical-rules.md` |
 | Analytics: `community_health`, `bad_actor_detection`, `user_journey`, `retention_cohorts`, `engagement_funnels` | Professional | v2.2.x `analytics_core_module` `PREMIUM_FEATURES` |
@@ -775,6 +790,21 @@ its source; rows sourced from "this design" are proposals, not standards.
 | WaddleAI integration | Enterprise | `critical-rules.md` |
 | Advanced analytics | Enterprise | `critical-rules.md` |
 | Dedicated Valkey / per-tenant infrastructure isolation | Enterprise | this design — see Transport limits |
+
+### Structural caps
+
+Two caps are structural rather than feature flags — they limit how many of a thing exists,
+not what it can do:
+
+| Cap | Free | Professional | Enterprise |
+|-----|------|--------------|------------|
+| Admins | 1 | many | many |
+| **Tenants** | **1 (default)** | **1 (default)** | **many** |
+
+Enforce tenant creation the way `critical-rules.md` enforces seats, not nodes: **block
+creation of a second tenant with an upgrade path, and never touch the existing one.** Tenant
+creation is a deliberate administrative act, so blocking it is safe; degrading an existing
+tenant would not be.
 
 **The residual commercial decision:** v2.2.x is effectively **two-tier** (free vs `premium`,
 with 83 `premium` references and `PREMIUM_BYPASS_DOMAINS`). The standard mandates three. Every
@@ -830,6 +860,7 @@ Detail lives in the companion plan. Summary:
 | Valkey becomes a single point of failure for the whole event path | It already is for cache and sessions; P0 sizes it for stream retention and configures persistence deliberately rather than inheriting cache defaults |
 | Per-tenant streams and ACL users grow linearly with the tenant roster | Pool per tenant with idle eviction and an active-tenant set; revisit in the low thousands, then shard via Cluster hash tags or dedicated Valkey rather than dropping isolation |
 | A "missing tenant means default" fallback outlives the migration and becomes a bypass | The fallback has a recorded cutoff date, after which unclaimed tokens are rejected |
+| The multi-tenant path rots because Free and Professional never exercise it | Single-tenant runs the identical code with N=1; no `if tenant == "default"` shortcut is permitted anywhere |
 | SPIRE deployed standalone, then federation with SkausWatch needs a topology change | Deploy as `child` with the upstream disabled from the start; promotion is a values flip plus a join token |
 | mTLS is treated as replacing the inter-service JWT | `security.md` requires both regardless of transport; the SVID-required test does not assert the JWT, so both need their own gate |
 | mTLS is enabled without a peer SPIFFE ID allowlist, so any workload in the trust domain is accepted | Per-service accepted-peer lists, with a test asserting a valid-but-unlisted SVID is rejected |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -253,7 +253,7 @@ the consolidated `StreamPipeline` that every stage links against to publish and 
 Valkey Streams. Putting a gRPC service in front of Valkey would add a hop and a failure
 domain to buy nothing; the stream broker is already the shared component.
 
-The command half stays in Bot, as a consumer of `waddles.process`.
+The command half stays in Bot, as a consumer of `waddles:t:{tenant}:process`.
 
 Without this split, Social, Customer and Marketing would each have to depend on Bot to emit
 an event — which would make the Modules interdependent and defeat global toggling.

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -677,6 +677,108 @@ Third-party Apps need none of this: they are always reached across a network bou
 (`webhook_push` or `rest_pull` — see Apps), so vendor code never shares a process with ours
 regardless of topology.
 
+## Compliance
+
+Waddles must satisfy **GDPR**, **CCPA/CPRA**, the **EU AI Act**, and **CRA**. This section
+covers what the *architecture* has to provide; scope and legal interpretation need counsel,
+and the obligations below are the engineering consequences, not a compliance opinion.
+
+> **CRA is ambiguous in this list.** Read as the EU **Cyber Resilience Act** it is a product-
+> security regulation — SBOM, coordinated vulnerability disclosure, a security-update
+> commitment across a support period. Read as the **Colorado Privacy Act** it is closer to
+> CCPA/CPRA. Confirm which before scoping; they imply different work.
+
+### Where this collides with decisions already made
+
+Four places, and they are the reason this cannot be bolted on at P5.
+
+#### PostHog is both the flag plane and an analytics tool
+
+This design uses PostHog for feature-flag evaluation. PostHog is *also* product analytics, and
+its browser SDK does both from one initialisation. Under GDPR/ePrivacy, flag evaluation needed
+to render the product is arguably strictly necessary; behavioural analytics is not and needs
+prior consent.
+
+They must therefore be separable in the client: **flags evaluate before consent, analytics
+capture does not.** Server-side flag evaluation for the webui avoids the question entirely and
+is the safer default — the browser never gets an analytics-capable SDK it has to be trusted to
+keep quiet.
+
+Getting this wrong is the classic finding in a cookie audit: a consent banner that blocks
+nothing because the analytics SDK initialised to fetch flags before the user answered.
+
+#### Streams are append-only, and erasure is not
+
+`waddles:t:{tenant}:{stage}` and the DLQ are logs. A GDPR erasure request against data sitting
+in a stream has no natural answer, because streams do not support selective deletion in the way
+a row does.
+
+Two disciplines make this tractable, and both are already required elsewhere in this design:
+
+- **Envelopes carry UUIDs, never PII** — `critical-rules.md`'s PII tokenization rule is what
+  makes stream erasure a non-problem: delete or anonymise the row in the single identity table
+  and the stream's references become inert.
+- **Streams have bounded retention.** An unbounded stream is an unbounded retention period,
+  which is a lawful-basis problem regardless of tokenization. Set `MAXLEN`/`MINID` per stream
+  deliberately; the DLQ especially, since poison events are exactly the ones that sit longest.
+
+#### Third-party Apps are sub-processors
+
+An App reached over `webhook_push` or `rest_pull` receives data about a community's users. That
+is a processor relationship, and the marketplace is what creates it.
+
+The architecture has to support: disclosing to a community what an App receives before install,
+recording that a community's admin accepted it, a DPA per vendor, and the App's endpoint on the
+tenant-scoped egress allowlist. The last of these is already in the design for security reasons;
+here it doubles as the enforcement point for "data goes only where disclosed".
+
+#### AI features carry transparency obligations
+
+`ai_interaction_module`, `ai_researcher_module` and the WaddleAI integration put Waddles in EU
+AI Act scope. Two consequences that touch the design rather than the policy:
+
+- **Disclosure**: users interacting with an AI system must be told. In Social and Bot that is a
+  per-message or per-surface marker, which is a Feature-contract concern rather than an
+  afterthought in one App.
+- **Automated assessment of people**: `bad_actor_detection` and `reputation_module` score users.
+  Whether that reaches a regulated risk tier needs legal input, but the architecture should
+  assume it might — meaning logged inputs, an explanation path, and human review — because
+  retrofitting explainability into a scoring system is far harder than designing for it.
+
+### Webui obligations
+
+The webui carries most of the visible surface:
+
+| Requirement | Source | Shape |
+|---|---|---|
+| Consent before non-essential cookies, granular by category, refusable as easily as accepted | GDPR/ePrivacy | consent gate in `hub-webui`; nothing non-essential initialises before it |
+| "Do Not Sell or Share My Personal Information" | CCPA/CPRA | opt-out link and a respected Global Privacy Control signal |
+| Access, deletion, correction, portability | GDPR + CCPA/CPRA | self-service DSAR flows, not a support ticket |
+| AI interaction disclosure | EU AI Act | visible marker wherever AI generates or scores |
+
+Consent state is per **user**, and users belong to communities within tenants — so consent
+records follow the same `global → tenant → community` scoping as everything else, and land in
+whichever regional deployment holds that user.
+
+### What already helps
+
+Three decisions in this design were made for other reasons and pay off here:
+
+- **Regional deployments** give data residency for real, since nothing crosses at the data layer.
+- **PII tokenization** (an existing standard) makes erasure a single-row operation.
+- **Per-tenant Valkey isolation** means a tenant's cached data is separable, not commingled.
+
+### What this adds to the plan
+
+Compliance is a **P0 concern for the plumbing** and a per-phase concern for surfaces:
+
+- P0: stream retention bounds; consent-safe flag evaluation; SBOM generation if CRA is the
+  Cyber Resilience Act.
+- P1: App install discloses what data an App receives; egress allowlist enforces it.
+- P3: AI disclosure markers land with Social's Features.
+- P5: DSAR flows, consent UI, and the CCPA opt-out are user-facing and belong with the webui
+  rewrite — but they cannot be *designed* at P5 if the data model does not already support them.
+
 ## Documentation
 
 `docs/` is 435 files and 615,000 words across 60 directories, **43 of which are one-per-module**
@@ -796,10 +898,10 @@ its source; rows sourced from "this design" are proposals, not standards.
 Waddles ships in two shapes, and they differ in *who owns the deployment* — which changes
 where entitlement attaches:
 
-| | Self-hosted | SaaS (`app.waddles.app`) |
+| | Self-hosted | SaaS (`app.waddles.app`, `{region}-app.waddles.app`) |
 |---|---|---|
 | Owner | the customer | PenguinTech |
-| Tenants | 1 (Free/Pro) or many (Enterprise) | many — one per Enterprise customer, plus PenguinTech's default |
+| Tenants | 1 (Free/Pro) or many (Enterprise) | many per deployment — one per Enterprise customer, plus that deployment's default |
 | Customer buys | a licence for their deployment | **a tenant**, or **an upgrade to their community inside our default tenant** |
 | Entitlement attaches at | the tenant | the tenant *or* the community |
 
@@ -841,12 +943,52 @@ The hostname does two things: it turns SaaS mode on, and it sets **how far down 
 | Host | SaaS | Bypass depth | Why |
 |------|------|--------------|-----|
 | `waddles*.penguintech.cloud` — `waddles`, `waddles-alpha`, `waddles-beta`, `waddles-gamma` | on | **global + community** — Pro and Enterprise free in every community | so Enterprise features are actually exercisable in alpha/beta |
-| **`app.waddles.app`** | on | **global only** — communities pay | the production SaaS deployment; PenguinTech's platform needs no licence, customers do |
+| **`app.waddles.app`, `{region}-app.waddles.app`** | on | **global only** — communities pay | the production SaaS deployments; PenguinTech's platform needs no licence, customers do |
 | `waddles.app` (apex) | n/a | n/a | the marketing site, not the product — no entitlement decision happens here |
 | anything else | off — self-hosted | none; licence validated against `license.penguintech.io` | |
 
-The product runs at **`app.waddles.app`**; the apex is the marketing site. Only the former
-ever resolves entitlement.
+The product runs at **`app.waddles.app`** and regional siblings such as
+**`eu-app.waddles.app`**; the apex is the marketing site. Only the product hosts resolve
+entitlement.
+
+##### Regional deployments are independent instances
+
+There is more than one production SaaS deployment, and the reason regions exist at all is
+**data residency** — an EU deployment is only meaningful if EU data stays inside it. That
+forces the boundary:
+
+| | Scope |
+|---|---|
+| Core, the seven containers, Valkey, Postgres | **per deployment** |
+| Tenants, communities — including the **default tenant** | **per deployment** |
+| Streams (`waddles:t:{tenant}:{stage}`) | **per deployment**; never cross-region |
+| Licence server (`license.penguintech.io`) | shared, external |
+| SPIRE | one child server per regional cluster, all nesting under the same `penguintech.io` root |
+
+A customer lives in exactly one deployment. "PenguinTech's default tenant" is therefore
+**per-region** — a self-serve EU customer joins the EU deployment's default tenant, not a
+global one. Nothing at the data layer is shared or replicated between regions, which is
+precisely what makes the residency claim true rather than aspirational.
+
+The nested SPIRE topology already handles this: each regional cluster is another `child`
+under the shared root, which is what that design is for. The SPIFFE ID pattern needs a region
+component so IDs stay unique across clusters — settle whether that is
+`spiffe://penguintech.io/{env}/{region}/{service}` or whether `{env}` absorbs the region.
+
+##### Open questions regional deployment raises
+
+None of these block P0, but all three need answers before a second region exists:
+
+- **Is the marketplace catalogue shared or per-deployment?** Community entitlement lives in
+  marketplace subscriptions, so a per-deployment marketplace fragments billing across regions
+  — the same customer could hold unrelated subscriptions in two regions. A shared catalogue
+  with per-deployment installations is the likely split, but it needs deciding rather than
+  emerging.
+- **Where does "which region is this customer in" live?** DNS alone does not answer it for a
+  user who arrives at the wrong host. A global directory mapping identity to region is a
+  cross-region service, which is in tension with residency.
+- **Is cross-region migration supported?** If yes it needs a documented procedure and an
+  export path; if no, say so plainly, because customers will ask.
 
 "Bypassed at global scale" is not "everything is free". It means the **global** level of the
 ladder is fully entitled — PenguinTech's own platform needs no licence to run — while tenant
@@ -895,9 +1037,11 @@ anything else containing the string. A licence bypass matched by substring is a 
 can claim by controlling a hostname, and in SaaS mode that is a revenue and data-isolation
 issue rather than a cosmetic one.
 
-Match full hostnames from an explicit allowlist — `app.waddles.app` exactly — and handle the
-`waddles*` prefix as a validated pattern anchored to the `penguintech.cloud` suffix. Never
-`in`.
+Match on parsed hostname structure, not string containment: an exact allowlist for the
+pre-production hosts, and for production a validated `{region-}app.waddles.app` pattern
+anchored to the full `waddles.app` suffix. Regional siblings mean the production match cannot
+be a fixed string either — `eu-app.waddles.app` must resolve, `eu-app.waddles.app.evil.net`
+must not. Never `in`.
 
 #### Where community-scoped entitlement lives
 
@@ -966,7 +1110,7 @@ Detail lives in the companion plan. Summary:
 
 | Phase | Work | Gate to exit |
 |-------|------|--------------|
-| P0 | Extract Core; delete `services/`'s 21 dead subdirs and harvest its aggregators; **propagate tenant scoping into the Python fleet**; Valkey + Streams as the stage transport; SPIFFE/SPIRE workload identity; collapse to seven containers; docs gate + restructure | Orphaned subdirs gone and every image still builds; cross-tenant isolation, redelivery, DLQ and idempotency tests all pass after first being made to fail; zero Alpine or unpinned images; gRPC call sites classified with counts |
+| P0 | Extract Core; delete `services/`'s 21 dead subdirs and harvest its aggregators; **propagate tenant scoping into the Python fleet**; Valkey + Streams as the stage transport; SPIFFE/SPIRE workload identity; collapse to seven containers; docs gate + restructure; compliance plumbing | Orphaned subdirs gone and every image still builds; cross-tenant isolation, redelivery, DLQ and idempotency tests all pass after first being made to fail; zero Alpine or unpinned images; gRPC call sites classified with counts |
 | P1 | App manifest, registry, binding resolution; rename to `app_installations`; convert 2–3 Bot units as proof | A community can rebind a Feature to a non-default App |
 | P2 | Bot — all triggers/actions/interactions become Apps | v2.2.x Bot parity, all as Apps |
 | P3 | Social — community, presence, RTC, browser-source as Apps | v2.2.x Social parity |
@@ -989,10 +1133,13 @@ Detail lives in the companion plan. Summary:
 | Per-tenant streams and ACL users grow linearly with the tenant roster | Pool per tenant with idle eviction and an active-tenant set; revisit in the low thousands, then shard via Cluster hash tags or dedicated Valkey rather than dropping isolation |
 | A "missing tenant means default" fallback outlives the migration and becomes a bypass | The fallback has a recorded cutoff date, after which unclaimed tokens are rejected |
 | The multi-tenant path rots because Free and Professional never exercise it | Single-tenant runs the identical code with N=1; no `if tenant == "default"` shortcut is permitted anywhere |
-| `app.waddles.app` is given the deep bypass, and every paying SaaS customer becomes free | Bypass depth is per-host and table-tested; `app.waddles.app` is global-only |
+| A production SaaS host is given the deep bypass, and every paying customer becomes free | Bypass depth is per-host-class and table-tested, covering every regional sibling |
 | Alpha and beta prove features work but never prove gating works | A restriction suite runs the denial cases with the domain injected, outside any bypassed environment |
 | The substring bypass match is spoofable by a controlled hostname | Full-hostname allowlist with the `waddles*` prefix validated against the `penguintech.cloud` suffix |
 | The marketplace becomes load-bearing for revenue but is sized as an extension catalogue | Stated deliberately in the design; its availability requirements are set for the billing path, not the browse path |
+| A consent banner blocks nothing because the analytics SDK initialised early to fetch feature flags | Flags resolve server-side for the webui; verified by loading with consent refused and asserting no analytics request |
+| Personal data accumulates in append-only streams with no retention bound and no erasure path | Bounded `MAXLEN`/`MINID` per stream, and envelopes carry UUIDs only, enforced by a field allowlist |
+| Third-party Apps receive user data without the community knowing what they receive | Install-time disclosure recorded against the community, plus the tenant-scoped egress allowlist as the enforcement point |
 | SPIRE deployed standalone, then federation with SkausWatch needs a topology change | Deploy as `child` with the upstream disabled from the start; promotion is a values flip plus a join token |
 | mTLS is treated as replacing the inter-service JWT | `security.md` requires both regardless of transport; the SVID-required test does not assert the JWT, so both need their own gate |
 | mTLS is enabled without a peer SPIFFE ID allowlist, so any workload in the trust domain is accepted | Per-service accepted-peer lists, with a test asserting a valid-but-unlisted SVID is rejected |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -720,31 +720,95 @@ pages deleted is reported alongside pages written.
 `README.md` and `docs/index.md` are rewritten last, at P5, once the structure beneath them is
 true.
 
-## Open decisions
+## Decisions
 
-These need a call before the phases they block:
+### Resolved
 
-1. **Which SPIRE root, if any.** Independent (self-signed child) is the default and needs no
-   decision. Nesting under SkausWatch's root needs a join token minted there and its trust
-   bundle published to this cluster — a cross-team coordination, not a code change. Blocks
-   nothing; decide per environment.
-2. **`core/module_rtc` is Go.** It is the seed of Social's conferencing story — precisely
-   where it would need to grow, which the Go phase-out rule says it should not. Rewrite in
-   Rust during P3, or grant a documented exception. Blocks P3.
-3. **The `services/` tree is a half-finished consolidation** with documented orphaned
-   duplicates (`docs/MODULE_CANONICAL_SOURCES.md`). v3 either completes it or deletes it;
-   keeping both trees is what produced the divergence. Blocks P0.
-4. **Tier mapping is not yet set.** Which Features land in Free vs Professional vs
-   Enterprise is a commercial decision, not an architectural one. Blocks the
-   `seeds/waddles.py` definition in P1.
+**`services/` is deleted — in two parts, at two different times.** Analysis of every
+`services/*/Dockerfile` shows the tree is two unrelated things:
 
-## Migration phases
+| Part | State | When |
+|------|-------|------|
+| 21 `*_module/` subdirectories | **provably dead** — each shadowed at build time by a `COPY` from the canonical tree | deleted in P0 |
+| 11 aggregator `app.py` / `config.py` / `requirements.txt` | **live**, and the prototype for the seven containers | harvested in P0, removed at P5 |
+
+Deleting only once we have confirmed nothing needs it — the standing condition — is satisfied
+for the 21 by proof rather than by waiting: nothing builds from them, so removing them cannot
+affect parity. The aggregators genuinely do need parity confirmed first, so they go at P5.
+
+`docs/MODULE_CANONICAL_SOURCES.md` documents **3** orphans. The real number is **21**, which
+is a reasonable measure of how quickly an undocumented duplicate tree drifts out of anyone's
+model of the system. Diverged config is ported out of all 21 before deletion, not just the
+three that were noticed.
+
+`services/interactive-social/app.py` is 846 lines already merging four modules into one Quart
+app. The seven-container consolidation is therefore partly prototyped rather than green-field
+— harvest it, but replace its `sys.path.insert` imports with real packaging.
+
+**`core/module_rtc` is rewritten in Rust** during P3, per the Go phase-out rule. It stays
+`svc-rtc` either way — UDP media transport cannot share a pod with HTTP stages — so the
+decision is language, not placement.
+
+**Tier mapping** — see below. The starting mapping is derived; the residual split is
+commercial.
+
+### Tier mapping
+
+Derived from `critical-rules.md`'s tier table and what v2.2.x already gates. Every row cites
+its source; rows sourced from "this design" are proposals, not standards.
+
+| Capability | Tier | Source |
+|------------|------|--------|
+| All four Modules, core functionality | Free | `critical-rules.md` — "Core product, no license-gated functionality" |
+| Bot: platform connectors, commands, interactions | Free | ungated in v2.2.x |
+| Social: chat, presence, communities | Free | ungated in v2.2.x |
+| Customer: accounts, contacts, opportunities | Free | lightweight by v3.0.0 scope |
+| Marketing: manual posting | Free | lightweight by v3.0.0 scope |
+| More than one admin | Professional | `critical-rules.md` — Free is capped at 1 admin |
+| Whitelabelling | Professional | `critical-rules.md` |
+| Google OAuth2 SSO | Professional | `critical-rules.md` |
+| Analytics: `community_health`, `bad_actor_detection`, `user_journey`, `retention_cohorts`, `engagement_funnels` | Professional | v2.2.x `analytics_core_module` `PREMIUM_FEATURES` |
+| Video proxy: 10 destinations, 5×2K, 15 Mbps, 90-day retention | Professional | v2.2.x `video_proxy_module` `PREMIUM_LIMITS` |
+| Marketing: scheduling and cross-platform publishing | Professional | this design — the paid half of Marketing |
+| SAML 2.0 / OIDC SSO | Enterprise | `critical-rules.md` |
+| Audit logs, external KMS | Enterprise | `critical-rules.md` |
+| WaddleAI integration | Enterprise | `critical-rules.md` |
+| Advanced analytics | Enterprise | `critical-rules.md` |
+| Dedicated Valkey / per-tenant infrastructure isolation | Enterprise | this design — see Transport limits |
+
+**The residual commercial decision:** v2.2.x is effectively **two-tier** (free vs `premium`,
+with 83 `premium` references and `PREMIUM_BYPASS_DOMAINS`). The standard mandates three. Every
+capability currently marked `premium` therefore has to land in Professional *or* Enterprise,
+and the rows above are a proposal for that split, not a reading of it. Confirm before P1
+seeds `waddles.py`.
+
+### A tier-name collision to settle
+
+The license server's tier enum is `("community", "professional", "enterprise")` — see
+`api/app/seeds/waddleai.py`. `critical-rules.md`'s table names the same tier **Free**.
+
+For most products that inconsistency is cosmetic. For Waddles it is not: **community is a
+first-class entity here** — the team/org level of `global → tenant → community`. A tier named
+`community` and an entity named `community` in the same codebase will produce exactly the
+kind of ambiguity the Vocabulary section exists to prevent.
+
+Use `free` in `seeds/waddles.py` and raise the mismatch with the license-server team rather
+than adopting `community` locally.
+
+### Still open
+
+**Which SPIRE root, per environment.** Independent (self-signed child) is the default and
+needs no decision. Nesting under SkausWatch's root needs a join token minted there and its
+trust bundle published to this cluster — cross-team coordination, not a code change. Blocks
+nothing; alpha can run self-signed while beta nests.
+
+## Migration phases## Migration phases
 
 Detail lives in the companion plan. Summary:
 
 | Phase | Work | Gate to exit |
 |-------|------|--------------|
-| P0 | Extract Core; resolve the `services/` tree; **propagate tenant scoping into the Python fleet**; Valkey + Streams as the stage transport; SPIFFE/SPIRE workload identity; collapse to seven containers; docs gate + restructure | One tree only; cross-tenant isolation, redelivery, DLQ and idempotency tests all pass after first being made to fail; zero Alpine or unpinned images; gRPC call sites classified with counts |
+| P0 | Extract Core; delete `services/`'s 21 dead subdirs and harvest its aggregators; **propagate tenant scoping into the Python fleet**; Valkey + Streams as the stage transport; SPIFFE/SPIRE workload identity; collapse to seven containers; docs gate + restructure | Orphaned subdirs gone and every image still builds; cross-tenant isolation, redelivery, DLQ and idempotency tests all pass after first being made to fail; zero Alpine or unpinned images; gRPC call sites classified with counts |
 | P1 | App manifest, registry, binding resolution; rename to `app_installations`; convert 2–3 Bot units as proof | A community can rebind a Feature to a non-default App |
 | P2 | Bot — all triggers/actions/interactions become Apps | v2.2.x Bot parity, all as Apps |
 | P3 | Social — community, presence, RTC, browser-source as Apps | v2.2.x Social parity |
@@ -757,7 +821,7 @@ Detail lives in the companion plan. Summary:
 |------|------------|
 | Tenant scoping lands late, so Feature/App gating is built on an untrustworthy claim | It is P0, before any App conversion; nothing above it is sound until it passes |
 | Feature contracts churn after third-party Apps exist | Version interfaces from P1; never ship an unversioned contract |
-| The two trees (`action/` + `services/`) diverge further during migration | Resolve in P0, before any App conversion touches them |
+| The two trees (`action/` + `services/`) diverge further during migration | The 21 dead subdirs are deleted in P0, before any App conversion touches them; only the aggregators survive, and they are build inputs so drift is visible |
 | "Lightweight CRM" expands under its own gravity | Customer's v3.0.0 scope is fixed at accounts/contacts/opportunities; anything more is 3.x |
 | Per-community App execution becomes an untrusted-code surface | Not in-process — `webhook_push`/`rest_pull` keep vendors across a network boundary. P1 must instead carry per-App egress allowlisting and timeout policy |
 | Seven shared containers widen blast radius vs. ~40 isolated ones | Accepted knowingly; pipeline stages are the split points when a Module earns one on evidence |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -663,6 +663,63 @@ Third-party Apps need none of this: they are always reached across a network bou
 (`webhook_push` or `rest_pull` — see Apps), so vendor code never shares a process with ours
 regardless of topology.
 
+## Documentation
+
+`docs/` is 435 files and 615,000 words across 60 directories, **43 of which are one-per-module**
+and dissolve entirely in v3. 277 files reference the old module and path names.
+
+The staleness has already started and nothing catches it: of 61 repository paths referenced
+in docs, **26 no longer exist** — a whole family of `*_interaction_module_flask/` directories
+among them. There is no docs check in CI of any kind.
+
+That is the failure mode to design against. Docs do not go stale because nobody cares; they
+go stale because nothing fails when they do.
+
+### Docs are a per-phase gate, not a final phase
+
+The obvious plan — migrate the code, then fix the docs at P5 — is what produces a 615k-word
+corpus describing a system that no longer exists. Instead, **every phase's exit gate includes
+its own documentation**, and a phase is not done until its docs are.
+
+### A docs check that can actually fail
+
+A gate nobody can fail is not a gate. CI grows a reference validator:
+
+- extract every repository path referenced in `docs/**/*.md`
+- assert each exists
+- fail on any that does not
+
+Seed it at the current baseline of **26 dead references** and ratchet the allowed count down,
+never up. That makes the existing debt visible without blocking P0 on it, and makes any *new*
+dead reference an immediate failure. Report the count of paths examined alongside the count
+of failures — a validator that finds zero references is broken, not clean.
+
+### Structure follows the hierarchy
+
+The 43 per-module directories are replaced by the layering this design introduces:
+
+```
+docs/
+  core/           one page per Core service
+  modules/        social · customer · bot · marketing
+    <module>/features/    one page per Feature contract, versioned with it
+  apps/           first-party App manifests and how to write a third-party one
+  deployment/     the seven containers, streams, tenancy, SPIFFE
+```
+
+A Feature's documentation is versioned with its contract. That is the page a third-party App
+author reads, so letting it drift is a public-API problem, not an internal tidiness one.
+
+### Delete, do not migrate
+
+Much of 615k words describes modules that will not exist in the same shape. Carrying it
+forward unexamined is worse than deleting it — a wrong page costs more than a missing one,
+because it is trusted. Each phase's docs work explicitly includes deletions, and the count of
+pages deleted is reported alongside pages written.
+
+`README.md` and `docs/index.md` are rewritten last, at P5, once the structure beneath them is
+true.
+
 ## Open decisions
 
 These need a call before the phases they block:
@@ -687,7 +744,7 @@ Detail lives in the companion plan. Summary:
 
 | Phase | Work | Gate to exit |
 |-------|------|--------------|
-| P0 | Extract Core; resolve the `services/` tree; **propagate tenant scoping into the Python fleet**; Valkey + Streams as the stage transport; SPIFFE/SPIRE workload identity; collapse to seven containers | One tree only; cross-tenant isolation, redelivery, DLQ and idempotency tests all pass after first being made to fail; zero Alpine or unpinned images; gRPC call sites classified with counts |
+| P0 | Extract Core; resolve the `services/` tree; **propagate tenant scoping into the Python fleet**; Valkey + Streams as the stage transport; SPIFFE/SPIRE workload identity; collapse to seven containers; docs gate + restructure | One tree only; cross-tenant isolation, redelivery, DLQ and idempotency tests all pass after first being made to fail; zero Alpine or unpinned images; gRPC call sites classified with counts |
 | P1 | App manifest, registry, binding resolution; rename to `app_installations`; convert 2–3 Bot units as proof | A community can rebind a Feature to a non-default App |
 | P2 | Bot — all triggers/actions/interactions become Apps | v2.2.x Bot parity, all as Apps |
 | P3 | Social — community, presence, RTC, browser-source as Apps | v2.2.x Social parity |
@@ -713,4 +770,6 @@ Detail lives in the companion plan. Summary:
 | mTLS is treated as replacing the inter-service JWT | `security.md` requires both regardless of transport; the SVID-required test does not assert the JWT, so both need their own gate |
 | mTLS is enabled without a peer SPIFFE ID allowlist, so any workload in the trust domain is accepted | Per-service accepted-peer lists, with a test asserting a valid-but-unlisted SVID is rejected |
 | Middleware layers get reordered during refactoring, and the happy path still passes | The ordering contract has its own test that reverses the layers and confirms the reversal is caught |
+| Docs are deferred to P5 and end up describing a system that no longer exists | Docs are a per-phase exit gate, backed by a reference validator that ratchets from a measured baseline of 26 dead references to zero |
+| 615k words are migrated unexamined, so wrong pages outlive the modules they describe | Each phase reports pages deleted alongside pages written; a wrong page costs more than a missing one |
 | CI rebuilds everything on any change | Seven images with path-filtered workflows, as `build-*.yml` already does per module |

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -796,7 +796,7 @@ its source; rows sourced from "this design" are proposals, not standards.
 Waddles ships in two shapes, and they differ in *who owns the deployment* — which changes
 where entitlement attaches:
 
-| | Self-hosted | SaaS (`waddles.app`) |
+| | Self-hosted | SaaS (`app.waddles.app`) |
 |---|---|---|
 | Owner | the customer | PenguinTech |
 | Tenants | 1 (Free/Pro) or many (Enterprise) | many — one per Enterprise customer, plus PenguinTech's default |
@@ -833,33 +833,71 @@ gets, not what a deployment contains:
 PenguinTech's SaaS deployment holds many tenants because PenguinTech operates it, not because
 it holds an Enterprise licence. Deployment size and customer tier are unrelated.
 
-#### The domain is a mode switch, not a bypass
+#### The domain selects a mode and a bypass depth
 
-SaaS mode activates on **`waddles.app`** or **`waddles.penguincloud.tech`**. The hostname
-therefore selects one of three modes, rather than toggling licensing on and off:
+The hostname does two things: it turns SaaS mode on, and it sets **how far down the
+`global → tenant → community` ladder the licence bypass reaches**.
 
-| Domain | Mode | Entitlement |
-|--------|------|-------------|
-| `waddles.app`, `waddles.penguincloud.tech` | **SaaS** | per tenant *or* per community, from billing — **never bypassed** |
-| `*.penguintech.cloud`, `*.penguincloud.io` | internal (beta/dev) | bypassed — PenguinTech's own non-production |
-| anything else | self-hosted | per-tenant licence validated against `license.penguintech.io` |
+| Host | SaaS | Bypass depth | Why |
+|------|------|--------------|-----|
+| `waddles*.penguintech.cloud` — `waddles`, `waddles-alpha`, `waddles-beta`, `waddles-gamma` | on | **global + community** — Pro and Enterprise free in every community | so Enterprise features are actually exercisable in alpha/beta |
+| **`app.waddles.app`** | on | **global only** — communities pay | the production SaaS deployment; PenguinTech's platform needs no licence, customers do |
+| `waddles.app` (apex) | n/a | n/a | the marketing site, not the product — no entitlement decision happens here |
+| anything else | off — self-hosted | none; licence validated against `license.penguintech.io` | |
 
-Reading the domain as a mode rather than a bypass is what keeps the SaaS chargeable. The two
-questions collapse into one in self-hosted deployments and separate in SaaS:
+The product runs at **`app.waddles.app`**; the apex is the marketing site. Only the former
+ever resolves entitlement.
 
-| Question | Answered by | In SaaS |
-|----------|-------------|---------|
-| Is this *deployment* licensed to run? | the mode | yes — PenguinTech owns it |
-| What tier is this *customer*? | the entitlement lookup | **never by the hostname** |
+"Bypassed at global scale" is not "everything is free". It means the **global** level of the
+ladder is fully entitled — PenguinTech's own platform needs no licence to run — while tenant
+and community entitlement still restricts beneath it. That is the ladder's existing rule doing
+its job: narrower levels restrict what a broader level granted, never expand it.
 
-**A standards conflict to settle before launch.** `penguintech.md` lists product-specific
-`.app` domains as hardcoded licence-bypass domains, and `waddles.app` is the product domain
-per `penguintech-reference`. Applied literally, every paying SaaS customer would get full
-entitlement free. Today's code happens to be correct — `PREMIUM_BYPASS_DOMAINS` in
-`video_proxy_module` lists only `waddlebot.penguintech.io`, `waddles.penguintech.cloud` and
-`waddles.penguincloud.io` — but that is luck rather than design. Raise the wording with the
-standards owner; `waddles.penguincloud.tech` is also outside every current bypass pattern and
-needs adding to the mode list explicitly.
+The pre-production domains go one level deeper for a specific reason: **you cannot test an
+Enterprise feature in an environment where nothing holds an Enterprise entitlement.** Without
+the community-level bypass, alpha and beta would exercise only the Free path, and every
+Enterprise code path would first run in production.
+
+##### Bypass satisfies the licence gate, never the flag gate
+
+A Feature needs **tier AND flag**. A domain bypass satisfies only the tier half — hence "all
+licensed features on *unless turned off*". PostHog still governs exposure, so a feature can be
+dark on a fully-bypassed domain, and a never-seen flag still defaults OFF.
+
+Keeping the two gates independent is what makes a bypassed domain safe to deploy to: it
+removes the commercial gate, not the rollout control.
+
+##### The bypass makes features testable and gating untestable
+
+This is the cost of the mechanism and it needs its own answer. In an environment where every
+community is entitled to everything, **the negative case never runs**: nothing there can show
+that a Free community is correctly *denied* an Enterprise feature. Alpha and beta would prove
+the features work and prove nothing about the gate that sells them.
+
+Both halves need coverage, in different places:
+
+| What | Where |
+|------|-------|
+| Enterprise features function | alpha/beta, via the community-level bypass |
+| Free and Pro are correctly *restricted* | integration tests against the entitlement resolver, with the domain injected — never inherited from the environment |
+| The bypass depth itself is correct per domain | a table-driven test over the domain classes, asserting resolved depth |
+
+The entitlement resolver must therefore take the domain as an **argument**, not read it from
+ambient config. A resolver that reads its own hostname cannot be tested for any environment it
+is not currently running in.
+
+##### Match full hostnames, not substrings
+
+Today's implementation is `if any(d in domain_lower for d in PREMIUM_BYPASS_DOMAINS)` — a
+substring test. With the product at `app.waddles.app`, a naive entry of `waddles.app` matches
+the real host *and* `waddles.app.attacker.example`, `evil-waddles.app.example.net`, and
+anything else containing the string. A licence bypass matched by substring is a bypass anyone
+can claim by controlling a hostname, and in SaaS mode that is a revenue and data-isolation
+issue rather than a cosmetic one.
+
+Match full hostnames from an explicit allowlist — `app.waddles.app` exactly — and handle the
+`waddles*` prefix as a validated pattern anchored to the `penguintech.cloud` suffix. Never
+`in`.
 
 #### Where community-scoped entitlement lives
 
@@ -951,7 +989,9 @@ Detail lives in the companion plan. Summary:
 | Per-tenant streams and ACL users grow linearly with the tenant roster | Pool per tenant with idle eviction and an active-tenant set; revisit in the low thousands, then shard via Cluster hash tags or dedicated Valkey rather than dropping isolation |
 | A "missing tenant means default" fallback outlives the migration and becomes a bypass | The fallback has a recorded cutoff date, after which unclaimed tokens are rejected |
 | The multi-tenant path rots because Free and Professional never exercise it | Single-tenant runs the identical code with N=1; no `if tenant == "default"` shortcut is permitted anywhere |
-| `waddles.app` is added to the bypass list per the standard, and the SaaS becomes free for every customer | The hostname selects a mode, never an entitlement; a test asserts a Free community on `waddles.app` resolves to Free |
+| `app.waddles.app` is given the deep bypass, and every paying SaaS customer becomes free | Bypass depth is per-host and table-tested; `app.waddles.app` is global-only |
+| Alpha and beta prove features work but never prove gating works | A restriction suite runs the denial cases with the domain injected, outside any bypassed environment |
+| The substring bypass match is spoofable by a controlled hostname | Full-hostname allowlist with the `waddles*` prefix validated against the `penguintech.cloud` suffix |
 | The marketplace becomes load-bearing for revenue but is sized as an extension catalogue | Stated deliberately in the design; its availability requirements are set for the billing path, not the browse path |
 | SPIRE deployed standalone, then federation with SkausWatch needs a topology change | Deploy as `child` with the upstream disabled from the start; promotion is a values flip plus a join token |
 | mTLS is treated as replacing the inter-service JWT | `security.md` requires both regardless of transport; the SVID-required test does not assert the JWT, so both need their own gate |

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -472,7 +472,33 @@ creation is a deliberate administrative act, so blocking it is safe.
 upgrade path, and the existing tenant keeps working throughout. Write it so it fails against
 an unenforced cap first.
 
-**Step 4:** Carry the confirmed mapping into `seeds/waddles.py` in Task 1.4.
+**Step 4: Implement SaaS mode as a three-way switch on the hostname**, not a bypass toggle:
+
+| Domain | Mode | Entitlement |
+|--------|------|-------------|
+| `waddles.app`, `waddles.penguincloud.tech` | SaaS | per tenant *or* per community, from billing — never bypassed |
+| `*.penguintech.cloud`, `*.penguincloud.io` | internal | bypassed |
+| anything else | self-hosted | per-tenant licence against `license.penguintech.io` |
+
+Entitlement resolves narrowest-first — **community → tenant** — mirroring App binding.
+
+The licence server has no sub-tenant scope, so community-level entitlement comes from
+**marketplace subscriptions**, not from a licence. Only the deployment/tenant tier is a
+licence. Widening the marketplace this way makes it load-bearing for revenue, not just
+extensions; size its availability requirements accordingly.
+
+**Test — this is the one that protects the revenue:** a request to `waddles.app` from a Free
+community resolves to Free, not to bypassed-premium. Write it so it fails against a
+`PREMIUM_BYPASS_DOMAINS` list that includes `waddles.app`, which is what the standard as
+written would produce.
+
+**Step 5: Raise the standards conflict.** `penguintech.md` lists product-specific `.app`
+domains as licence-bypass domains and `waddles.app` is the product domain. Applied literally,
+every paying SaaS customer gets full entitlement free. Today's code is accidentally correct.
+`waddles.penguincloud.tech` is also outside every current bypass pattern and needs adding to
+the mode list explicitly.
+
+**Step 6:** Carry the confirmed mapping into `seeds/waddles.py` in Task 1.4.
 
 ### Task 1.2: Define the App manifest schema
 

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -87,10 +87,45 @@ and acking — port anything `MessageQueue` has that it lacks, then delete `Mess
 grep -rl "MessageQueue\|create_message_queue" --include="*.py" . | grep -v node_modules   # migrate every caller
 ```
 
-**Step 3: Streams become the default path, not an opt-in.** Today `StreamPipeline` is used
-by one service behind a flag. Remove the flag; `svc-ingest` → `svc-process` → `svc-action`
-communicate by stream. Four streams: `waddles.ingest`, `waddles.process`, `waddles.action`,
-`waddles.dlq`.
+**Step 3: Streams become the default path, not an opt-in, and they are per tenant.** Today
+`StreamPipeline` is used by one service behind a flag. Remove the flag; `svc-ingest` →
+`svc-process` → `svc-action` communicate by stream.
+
+Streams and every other key carry a tenant segment:
+```
+waddles:t:{tenant}:{stage}          ingest · process · action · dlq
+waddles:t:{tenant}:{concern}:...    cache · sessions · rate limits
+```
+
+Everything currently lives in the default tenant and continues to, so this is a rename:
+`waddlebot:cache:*` → `waddles:t:default:cache:*`. Write the rename as a migration, not a
+flag day — dual-read old and new prefixes, backfill, then drop the old reader.
+
+The default tenant must use the **same** code path as any other. A branch that skips the
+tenant segment for `default` is a backdoor that will outlive the migration.
+
+**Step 3b: Per-(tenant, stage) Valkey ACL users.** `docs/architecture/redis-architecture.md`
+already specifies per-service ACL users and is implemented nowhere. Implement it, composed
+with tenancy:
+
+```
+ACL SETUSER waddles-t-{tenant}-{stage} on >{secret} \
+    ~waddles:t:{tenant}:* +@read +@write +@stream -@dangerous
+```
+
+Credentials go in `credential_manager_module` and rotate there — never in values files.
+
+Pool connections per tenant with idle eviction, and keep an active-tenant set so a stage
+holds readers only for tenants with traffic. Connection count is tenants × stages × replicas
+and is the binding constraint; record the number this deployment expects.
+
+**Verify the ACL actually denies — this is the whole point:**
+```bash
+pytest tests/streams/test_tenant_acl_denies.py -v
+```
+Connect as tenant A's user, attempt a read of a tenant B key, assert `NOPERM`. Write it so
+it fails against a permissive ACL first. An isolation control that has never denied anything
+is not known to deny.
 
 **Step 4: Retire most of the gRPC mesh.** The 21 gRPC call sites, the port registry and the
 per-module `.proto` files exist because two dozen containers had to talk. Collapsing to seven
@@ -159,6 +194,8 @@ wc -l < /tmp/tenant-scope.txt   # assert non-zero; this is the denominator
 A later "all done" claim must cite this number. Zero files examined is a failure, not a pass.
 
 **Step 2: Add the `tenant` claim** to `create_jwt_token`/`verify_jwt_token`. Per `security.md` the claim is mandatory on every token — reject tokens without it rather than defaulting.
+
+Existing tokens carry no tenant. Issue them as the **default tenant** during the migration window, and reject unclaimed tokens once that window closes — a permanent "missing means default" fallback is the untenanted backdoor in a different shape. Set and record the cutoff date.
 
 **Step 3: Tenant middleware runs first**, before scope checks. Mismatch is 403. The client cannot set tenant; it comes from the validated JWT only.
 
@@ -241,6 +278,8 @@ never observed failing is not known to work.
 - Zero Alpine and zero unpinned images in `k8s/`; Valkey and Postgres bookworm, digest-pinned.
 - gRPC call-site classification reported as three counts against the starting 21.
 - Redelivery, DLQ and idempotency tests pass, each on record as having failed first.
+- Cross-tenant Valkey read returns `NOPERM`, proven by a test that has been made to fail.
+- No key path bypasses the tenant segment, including for the default tenant.
 - Cross-tenant isolation test passes, and is on record as having failed against pre-P0 code.
 - Tenant-scoping count reported against the Step 1 denominator, not asserted as "all".
 - `helm template` renders exactly 7 Deployments, all `runAsNonRoot: true`, reported against

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -54,19 +54,91 @@ Expected Core set (verify, do not assume): identity, security, credentials, tena
 
 Expected Module-owned but currently sitting in `core/`: `browser_source_core_module` and `video_proxy_module` (Social only), `engagement_module` (Marketing only), `reputation_module` and `labels_core_module` (verify — likely Social + Bot, therefore Core).
 
-### Task 0.3: Split the router
+### Task 0.3: Migrate to Valkey and make Streams the stage transport
 
 **Files:**
-- Create: `core/event_bus_module/`
+- Modify: `k8s/helm/waddlebot/values.yaml`, `values-beta.yaml`, `k8s/infrastructure.yaml`, `k8s/kustomize/components/infrastructure/redis.yaml`, `k8s/manifests/infrastructure/redis.yaml`
+- Modify: `libs/flask_core/flask_core/stream_pipeline.py`
+- Delete: `libs/flask_core/flask_core/message_queue.py`
+
+**Step 1: Base images — Valkey, bookworm, digest-pinned.** Eight manifest entries break the
+base-image rules: `redis:7-alpine` (4) and `postgres:15/16-alpine` (4). Three violations
+each — Redis instead of Valkey, Alpine instead of Debian bookworm, and no digest. Postgres
+is additionally split across two majors.
+
+```bash
+grep -rn "image:.*\(redis\|postgres\).*alpine" --include="*.yaml" k8s/ | wc -l   # expect 8, then 0
+```
+
+Move to `valkey/valkey:8-bookworm@sha256:<digest>` and `postgres:17-bookworm@sha256:<digest>`.
+Look every digest up per the `pinning-dependency-digests` skill — never by hand.
+
+**Verify:**
+```bash
+! grep -rn "alpine" --include="*.yaml" k8s/          # zero Alpine anywhere
+! grep -rEn "image: (redis|postgres):[^@]*$" --include="*.yaml" k8s/   # zero unpinned tags
+```
+
+**Step 2: Consolidate the two Streams abstractions.** `StreamPipeline` and `MessageQueue`
+both wrap `XADD`/`XREADGROUP`. Keep `StreamPipeline` — it already has consumer groups, DLQ
+and acking — port anything `MessageQueue` has that it lacks, then delete `MessageQueue`.
+
+```bash
+grep -rl "MessageQueue\|create_message_queue" --include="*.py" . | grep -v node_modules   # migrate every caller
+```
+
+**Step 3: Streams become the default path, not an opt-in.** Today `StreamPipeline` is used
+by one service behind a flag. Remove the flag; `svc-ingest` → `svc-process` → `svc-action`
+communicate by stream. Four streams: `waddles.ingest`, `waddles.process`, `waddles.action`,
+`waddles.dlq`.
+
+**Step 4: Retire most of the gRPC mesh.** The 21 gRPC call sites, the port registry and the
+per-module `.proto` files exist because two dozen containers had to talk. Collapsing to seven
+removes most of that need rather than re-plumbing it.
+
+Enumerate all 21 gRPC and 56 HTTP call sites and classify each into exactly one bucket:
+
+| Bucket | Action |
+|--------|--------|
+| both ends land in the same stage container | **delete the RPC** — it becomes a function call; remove its proto and port |
+| event path across stages | convert to a stream publish |
+| synchronous and cross-container (→ `svc-core`) | keep as gRPC |
+
+Report the three counts. "Reduced gRPC usage" without them is not a result. Expect the third
+bucket to be small — essentially the entitlement and identity paths.
+
+`backend.md`'s gRPC mandate still governs bucket three. Bucket one stops being
+service-to-service, so the mandate no longer applies — this is surface reduction, not an
+exception.
+
+**Step 5: Consumers must be idempotent.** At-least-once redelivery is the point of consumer
+groups, so every envelope carries an id and consumers dedupe on it. A consumer without a
+dedupe path is a duplicate-post bug waiting for its first redelivery.
+
+**Verify — prove redelivery and the DLQ actually work:**
+```bash
+pytest tests/streams/test_redelivery.py -v      # kill a consumer mid-ack; event must redeliver
+pytest tests/streams/test_dlq.py -v             # poison event lands in waddles.dlq, not retried forever
+pytest tests/streams/test_idempotency.py -v     # same envelope id twice = one effect
+```
+Write each so it fails first. A redelivery test that has never gone red proves nothing.
+
+### Task 0.3b: Split the router
+
+**Files:**
 - Modify: `processing/router_module/`
 
-**Step 1:** Identify the split line. In `processing/router_module/services/`, generic routing and pub/sub move to the event bus; `command_registry.py`, cooldown handling, and emote services stay with Bot.
+**Step 1:** The generic half becomes the Core event bus — which is the consolidated
+`StreamPipeline` **library**, not a new service. Do not create `core/event_bus_module`;
+putting a gRPC service in front of Valkey adds a hop and a failure domain for nothing.
 
-**Step 2:** The event bus exposes publish/subscribe over gRPC (port 50051, `api_version` field per `backend.md`) with no Twitch/Discord vocabulary in its interface. If a Customer-module developer reading the event bus API sees the word "command" or "emote", the split is wrong.
+**Step 2:** `command_registry.py`, cooldown handling and emote services stay with Bot, as a
+consumer of `waddles.process`.
 
-**Step 3:** Bot's command dispatch becomes a *consumer* of the event bus, not a peer of it.
+**Step 3:** No Twitch/Discord vocabulary may appear in the shared library. If a
+Customer-module developer reading it sees "command" or "emote", the split is wrong.
 
-**Verify:** `grep -riE "twitch|discord|emote|command" core/event_bus_module/ --include=*.py` returns nothing outside comments.
+**Verify:** `grep -riE "twitch|discord|emote|command" libs/flask_core/flask_core/stream_pipeline.py` returns nothing outside comments.
 
 ### Task 0.4: Propagate tenant scoping into the Python fleet
 
@@ -165,7 +237,10 @@ never observed failing is not known to work.
 
 - One module tree only; `MODULE_CANONICAL_SOURCES.md` deleted or reduced to history.
 - Core deploys with all four Modules off, and the render is verified non-empty.
-- Event bus contains no platform-specific vocabulary.
+- Event bus library contains no platform-specific vocabulary.
+- Zero Alpine and zero unpinned images in `k8s/`; Valkey and Postgres bookworm, digest-pinned.
+- gRPC call-site classification reported as three counts against the starting 21.
+- Redelivery, DLQ and idempotency tests pass, each on record as having failed first.
 - Cross-tenant isolation test passes, and is on record as having failed against pre-P0 code.
 - Tenant-scoping count reported against the Step 1 denominator, not asserted as "all".
 - `helm template` renders exactly 7 Deployments, all `runAsNonRoot: true`, reported against

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -365,7 +365,48 @@ done
 Run it with the flag ON first and confirm it fails for each stage Social occupies. A toggle
 never observed failing is not known to work.
 
-### Task 0.6: Documentation gate and restructure
+### Task 0.7: Compliance plumbing
+
+GDPR, CCPA/CPRA, EU AI Act and CRA apply. The user-facing surfaces land at P5, but three
+things must be right in P0 or they cannot be added later without rework.
+
+**Confirm what CRA means first.** EU Cyber Resilience Act (SBOM, coordinated vulnerability
+disclosure, security-update commitment) and Colorado Privacy Act imply different work. Ask
+before scoping.
+
+**Step 1: Bound stream retention.** `waddles:t:{tenant}:{stage}` and the DLQ are append-only
+logs; an unbounded stream is an unbounded retention period. Set `MAXLEN`/`MINID` per stream
+deliberately — the DLQ especially, since poison events sit longest.
+
+```bash
+pytest tests/streams/test_retention.py -v   # a stream past its bound is trimmed
+```
+
+**Step 2: Envelopes carry UUIDs, never PII.** This is `critical-rules.md`'s PII tokenization
+rule, and it is what makes stream erasure tractable: delete or anonymise the single identity
+row and stream references go inert. Selective deletion from a stream is not a thing.
+
+```bash
+pytest tests/streams/test_no_pii_in_envelope.py -v   # assert against a field allowlist
+```
+Write it as an allowlist of permitted envelope fields, not a denylist of PII-looking names —
+a denylist passes for every field nobody thought of.
+
+**Step 3: Consent-safe flag evaluation.** PostHog is the flag plane *and* an analytics tool,
+initialised from one SDK. Flag evaluation needed to render the product is arguably strictly
+necessary; behavioural analytics is not and needs prior consent.
+
+Evaluate flags **server-side** for the webui. That removes the question rather than answering
+it — the browser never receives an analytics-capable SDK that must be trusted to stay quiet
+before the user answers the banner.
+
+**Verify:** load the webui with consent refused and assert no analytics request leaves the
+browser, while flags still resolve. This is the check a cookie audit runs; run it first.
+
+**Step 4: SBOM**, if CRA is the Cyber Resilience Act. Generate per image in CI; the digest
+pinning and scanning already in place are the inputs.
+
+
 
 `docs/` is 435 files and 615k words over 60 directories; 43 are one-per-module and dissolve
 in v3. **26 of 61 referenced repository paths are already dead** and no CI check exists.
@@ -433,6 +474,8 @@ Report pages deleted alongside pages written.
 - `scripts/check-doc-refs.sh` runs in CI, has been made to fail on purpose, and the dead-
   reference budget is at or below its P0 target.
 - P0's own documentation is written and its deletions reported.
+- Stream retention bounded and tested; envelope PII allowlist enforced; webui resolves flags
+  with consent refused and emits no analytics.
 
 ---
 
@@ -477,7 +520,7 @@ an unenforced cap first.
 | Domain | SaaS | Bypass depth |
 |--------|------|--------------|
 | `waddles*.penguintech.cloud` (`waddles`, `-alpha`, `-beta`, `-gamma`) | on | global + community — Pro/Enterprise free in every community |
-| `app.waddles.app` | on | global only — communities pay |
+| `app.waddles.app`, `{region}-app.waddles.app` | on | global only — communities pay |
 | anything else | off | none; licence checked |
 
 The pre-production depth exists so Enterprise features are exercisable before production;
@@ -495,8 +538,16 @@ currently running in, which is most of them.
 `waddles.app` apex is the marketing site. Today's check is
 `if any(d in domain_lower for d in PREMIUM_BYPASS_DOMAINS)`, so an entry of `waddles.app`
 matches the real host *and* `waddles.app.attacker.example`. In SaaS mode a spoofable bypass is
-a revenue and isolation issue. Allowlist `app.waddles.app` exactly, and anchor the `waddles*`
-prefix to the `penguintech.cloud` suffix; never `in`.
+a revenue and isolation issue. Match on parsed hostname structure: an exact
+allowlist for pre-production, and a validated `{region-}app.waddles.app` pattern anchored to
+the full suffix for production — regional siblings mean it cannot be a fixed string either.
+`eu-app.waddles.app` must resolve; `eu-app.waddles.app.evil.net` must not. Never `in`.
+
+**Step 4d: Nothing crosses a regional boundary at the data layer.** Each deployment has its
+own Core, Valkey, Postgres, streams, tenants and **its own default tenant** — data residency
+is the reason regions exist, so a shared or replicated data path defeats it. Assert it: no
+stream key, cache key or query in the codebase may be constructed from a region other than
+the running deployment's.
 
 **Step 5: Test both halves — the bypass makes features testable and gating untestable.**
 In an environment where every community is entitled to everything, the negative case never
@@ -611,7 +662,7 @@ Convert all `trigger/receiver/*`, `action/pushing/*`, `action/interactive/*` uni
 
 Convert `community_module`, `presence`, `alias`, `quote`, `shoutout`, `video_proxy`, `browser_source_core`. **`module_rtc` is rewritten in Rust** in this phase, per the Go phase-out rule — decided, no longer a blocker. It stays `svc-rtc` regardless, since UDP media transport cannot share a pod with the HTTP stages.
 
-**Gate:** v2.2.x Social functionality reachable through Feature bindings; chat and communities usable without Bot deployed. Social's Feature pages written, its per-module docs deleted, budget lowered.
+**Gate:** v2.2.x Social functionality reachable through Feature bindings; chat and communities usable without Bot deployed. AI interaction disclosure markers ship with the Features that generate or score, not afterwards. Social's Feature pages written, its per-module docs deleted, budget lowered.
 
 ### P4 — Customer and Marketing, lightweight
 
@@ -625,7 +676,7 @@ Customer: accounts, contacts, opportunities. Marketing: scheduling plus basic an
 
 Delete what remains of `services/` — the 11 aggregators, superseded by the seven container templates from Task 0.5. This is the phase where parity is confirmed, which is the condition for removing them.
 
-**Gate:** parity verified against v2.2.x with a documented comparison, not an assertion. `services/` fully removed, its aggregators superseded by the seven container templates. Every Module toggles off cleanly. Upgrade path from v2.2.x exercised on gamma per `deploying-app`. `README.md` and `docs/index.md` rewritten; dead-reference budget is **zero**.
+**Gate:** parity verified against v2.2.x with a documented comparison, not an assertion. `services/` fully removed, its aggregators superseded by the seven container templates. Every Module toggles off cleanly. Upgrade path from v2.2.x exercised on gamma per `deploying-app`. `README.md` and `docs/index.md` rewritten; dead-reference budget is **zero**. DSAR flows (access, deletion, correction, portability), the consent gate and the CCPA opt-out ship with the webui — designed against the P0 data model, not retrofitted.
 
 ---
 

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -472,31 +472,49 @@ creation is a deliberate administrative act, so blocking it is safe.
 upgrade path, and the existing tenant keeps working throughout. Write it so it fails against
 an unenforced cap first.
 
-**Step 4: Implement SaaS mode as a three-way switch on the hostname**, not a bypass toggle:
+**Step 4: Implement the domain as a mode switch plus a bypass depth**, not a boolean bypass:
 
-| Domain | Mode | Entitlement |
-|--------|------|-------------|
-| `waddles.app`, `waddles.penguincloud.tech` | SaaS | per tenant *or* per community, from billing — never bypassed |
-| `*.penguintech.cloud`, `*.penguincloud.io` | internal | bypassed |
-| anything else | self-hosted | per-tenant licence against `license.penguintech.io` |
+| Domain | SaaS | Bypass depth |
+|--------|------|--------------|
+| `waddles*.penguintech.cloud` (`waddles`, `-alpha`, `-beta`, `-gamma`) | on | global + community — Pro/Enterprise free in every community |
+| `app.waddles.app` | on | global only — communities pay |
+| anything else | off | none; licence checked |
 
-Entitlement resolves narrowest-first — **community → tenant** — mirroring App binding.
+The pre-production depth exists so Enterprise features are exercisable before production;
+without it, every Enterprise code path would first run for a paying customer.
 
-The licence server has no sub-tenant scope, so community-level entitlement comes from
-**marketplace subscriptions**, not from a licence. Only the deployment/tenant tier is a
-licence. Widening the marketplace this way makes it load-bearing for revenue, not just
-extensions; size its availability requirements accordingly.
+Entitlement resolves narrowest-first — **community → tenant** — mirroring App binding. The
+licence server has no sub-tenant scope, so community tier comes from **marketplace
+subscriptions**; only the deployment/tenant tier is a licence.
 
-**Test — this is the one that protects the revenue:** a request to `waddles.app` from a Free
-community resolves to Free, not to bypassed-premium. Write it so it fails against a
-`PREMIUM_BYPASS_DOMAINS` list that includes `waddles.app`, which is what the standard as
-written would produce.
+**Step 4b: The resolver takes the domain as an argument.** It must not read its own hostname
+from ambient config — a resolver that does cannot be tested for any environment it is not
+currently running in, which is most of them.
 
-**Step 5: Raise the standards conflict.** `penguintech.md` lists product-specific `.app`
-domains as licence-bypass domains and `waddles.app` is the product domain. Applied literally,
-every paying SaaS customer gets full entitlement free. Today's code is accidentally correct.
-`waddles.penguincloud.tech` is also outside every current bypass pattern and needs adding to
-the mode list explicitly.
+**Step 4c: Match full hostnames, not substrings.** The product runs at `app.waddles.app`;
+`waddles.app` apex is the marketing site. Today's check is
+`if any(d in domain_lower for d in PREMIUM_BYPASS_DOMAINS)`, so an entry of `waddles.app`
+matches the real host *and* `waddles.app.attacker.example`. In SaaS mode a spoofable bypass is
+a revenue and isolation issue. Allowlist `app.waddles.app` exactly, and anchor the `waddles*`
+prefix to the `penguintech.cloud` suffix; never `in`.
+
+**Step 5: Test both halves — the bypass makes features testable and gating untestable.**
+In an environment where every community is entitled to everything, the negative case never
+runs. Three suites, not one:
+
+```bash
+pytest tests/entitlement/test_features_function.py   # Enterprise features work under bypass
+pytest tests/entitlement/test_restriction.py         # Free/Pro correctly DENIED, domain injected
+pytest tests/entitlement/test_bypass_depth.py        # table-driven over domain classes
+```
+
+The restriction suite is the one that protects revenue, and the one a bypassed environment
+cannot provide. Write it so it fails against a resolver that always returns entitled.
+
+**Step 5b: Raise the standards conflict.** `penguintech.md` lists product-specific `.app`
+domains as licence-bypass domains and `waddles.app` is the product domain. Applied literally
+it would grant the SaaS host the *deep* bypass, making every paying customer free.
+`app.waddles.app` takes the global-only depth.
 
 **Step 6:** Carry the confirmed mapping into `seeds/waddles.py` in Task 1.4.
 

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -333,6 +333,55 @@ done
 Run it with the flag ON first and confirm it fails for each stage Social occupies. A toggle
 never observed failing is not known to work.
 
+### Task 0.6: Documentation gate and restructure
+
+`docs/` is 435 files and 615k words over 60 directories; 43 are one-per-module and dissolve
+in v3. **26 of 61 referenced repository paths are already dead** and no CI check exists.
+Docs go stale because nothing fails when they do — so build the failing thing first.
+
+**Step 1: The reference validator, before any docs are moved.**
+
+Create `scripts/check-doc-refs.sh`: extract every repo path referenced in `docs/**/*.md`,
+assert each exists, fail on any that does not.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+refs=$(grep -rhoE '`(action|core|trigger|processing|services|libs|admin|k8s)/[a-zA-Z0-9_/-]+`' \
+        docs/ --include='*.md' | tr -d '`' | sed 's:/$::' | sort -u)
+total=$(printf '%s\n' "$refs" | grep -c . || true)
+[ "$total" -gt 0 ] || { echo "FAIL: zero references extracted — validator is broken"; exit 1; }
+dead=0
+for r in $refs; do [ -e "$r" ] || { echo "dead: $r"; dead=$((dead+1)); }; done
+echo "examined=$total dead=$dead allowed=${DOC_REF_BUDGET:-0}"
+[ "$dead" -le "${DOC_REF_BUDGET:-0}" ]
+```
+
+Note the zero-references guard: a validator pointed at a moved directory finds nothing and
+reports clean. The denominator is part of the result.
+
+**Step 2: Seed the budget at today's debt, then ratchet.** Wire it into CI and
+`make lint` with `DOC_REF_BUDGET=26` — the measured baseline, verified by running the script. Lower it as phases land; never raise it. Existing debt
+stays visible without blocking P0, and any *new* dead reference fails immediately.
+
+**Verify it fails on purpose:** add a reference to a path that does not exist, confirm CI
+goes red, remove it.
+
+**Step 3: Restructure to mirror the hierarchy**, replacing the 43 per-module directories:
+
+```
+docs/core/          one page per Core service
+docs/modules/<m>/features/    one page per Feature contract, versioned with it
+docs/apps/          first-party manifests + how to write a third-party App
+docs/deployment/    the seven containers, streams, tenancy, SPIFFE
+```
+
+**Step 4: Delete rather than migrate.** Much of 615k words describes modules that will not
+exist in this shape. A wrong page costs more than a missing one because it is trusted.
+Report pages deleted alongside pages written.
+
+`README.md` and `docs/index.md` are rewritten at P5, once the structure beneath them is true.
+
 ### P0 exit gate
 
 - One module tree only; `MODULE_CANONICAL_SOURCES.md` deleted or reduced to history.
@@ -349,6 +398,9 @@ never observed failing is not known to work.
 - Tenant-scoping count reported against the Step 1 denominator, not asserted as "all".
 - `helm template` renders exactly 7 Deployments, all `runAsNonRoot: true`, reported against
   the pre-consolidation count.
+- `scripts/check-doc-refs.sh` runs in CI, has been made to fail on purpose, and the dead-
+  reference budget is at or below its P0 target.
+- P0's own documentation is written and its deletions reported.
 
 ---
 
@@ -449,13 +501,13 @@ Task detail for each is written when its predecessor's gate is met.
 
 Convert all `trigger/receiver/*`, `action/pushing/*`, `action/interactive/*` units to Apps.
 
-**Gate:** v2.2.x Bot functionality reachable entirely through Feature bindings; no privileged built-in path remains. Regression suite from v2.2.x passes against the App-routed implementation.
+**Gate:** v2.2.x Bot functionality reachable entirely through Feature bindings; no privileged built-in path remains. Regression suite from v2.2.x passes against the App-routed implementation. Bot's Feature pages written, its dissolved per-module docs deleted, and the dead-reference budget lowered.
 
 ### P3 — Social as Apps
 
 Convert `community_module`, `presence`, `alias`, `quote`, `shoutout`, `video_proxy`, `browser_source_core`. **Blocked by the `module_rtc` decision** — it is Go, and Social's conferencing story is where it would grow, which the Go phase-out rule forbids. Rewrite in Rust or grant a documented exception before starting.
 
-**Gate:** v2.2.x Social functionality reachable through Feature bindings; chat and communities usable without Bot deployed.
+**Gate:** v2.2.x Social functionality reachable through Feature bindings; chat and communities usable without Bot deployed. Social's Feature pages written, its per-module docs deleted, budget lowered.
 
 ### P4 — Customer and Marketing, lightweight
 
@@ -463,11 +515,11 @@ Customer: accounts, contacts, opportunities. Marketing: scheduling plus basic an
 
 **Scope is fixed here.** Customer is a full CRM eventually and Marketing a full suite; neither is in v3.0.0. Anything beyond the listed entities is 3.x with its own spec.
 
-**Gate:** both Modules deploy, toggle globally, and expose at least one rebindable Feature each — proving the pattern holds for green-field Modules, not just converted ones.
+**Gate:** both Modules deploy, toggle globally, and expose at least one rebindable Feature each — proving the pattern holds for green-field Modules, not just converted ones. Feature pages written for both.
 
 ### P5 — Cut v3.0.0
 
-**Gate:** parity verified against v2.2.x with a documented comparison, not an assertion. Every Module toggles off cleanly. Upgrade path from v2.2.x exercised on gamma per `deploying-app`.
+**Gate:** parity verified against v2.2.x with a documented comparison, not an assertion. Every Module toggles off cleanly. Upgrade path from v2.2.x exercised on gamma per `deploying-app`. `README.md` and `docs/index.md` rewritten; dead-reference budget is **zero**.
 
 ---
 

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -175,6 +175,57 @@ Customer-module developer reading it sees "command" or "emote", the split is wro
 
 **Verify:** `grep -riE "twitch|discord|emote|command" libs/flask_core/flask_core/stream_pipeline.py` returns nothing outside comments.
 
+### Task 0.3c: SPIFFE/SPIRE workload identity
+
+**Files:**
+- Create: `k8s/helm/waddlebot/charts/spire/` (adopt the `skauswatch-spire` chart shape)
+- Create: `libs/flask_core/flask_core/workload_identity.py`
+- Modify: `values.yaml`, `alpha.yml`, `beta.yml`, `gamma.yml`, `production.yml`
+
+The codebase has **zero** SPIFFE references outside standards docs. Seven containers make
+this tractable — seven registration entries per environment rather than forty.
+
+**Step 1: Deploy as `child` with the upstream disabled**, not as `standalone`:
+```yaml
+spire:
+  trustDomain: penguintech.io
+  topology:
+    role: child
+    upstreamRoot:
+      enabled: false        # flip true to nest under an external root
+```
+The chart promotes a child to nested mode without a `topology.role` change — it needs only a
+join token and the root's trust bundle. `standalone` would buy nothing now and force a
+topology change to federate with SkausWatch later.
+
+**Step 2: SPIRE agent DaemonSet**, Workload API socket mounted into each pod. Registration
+entries per `penguintech.md`: `spiffe://penguintech.io/{env}/{service}` for each of the seven.
+
+**Step 3: SPIFFE-ready is the requirement, not SPIFFE-deployed.** Services accept an
+X.509-SVID as a first-class identity mechanism whether or not SPIRE runs in that
+environment, so enabling it elsewhere is configuration rather than a rewrite.
+
+**Step 4: mTLS does not replace the JWT.** Per `security.md`, every inter-service call
+carries a short-lived signed JWT regardless of transport. Apply to both remaining call
+shapes: stage → `svc-core` gRPC, and stage → Valkey (client-cert TLS).
+
+**Step 5: Do not conflate SVID with tenancy.** An SVID identifies a workload, not a tenant.
+It composes with the per-(tenant, stage) ACL users from Task 0.3b; it does not replace them.
+A stage authenticating with its SVID still reaches only the keyspaces its tenant ACL user
+permits.
+
+**Verify:**
+```bash
+kubectl exec -n waddles deploy/svc-core -- \
+  /opt/spire/bin/spire-agent api fetch x509 -socketPath /run/spire/sockets/agent.sock
+# assert the SPIFFE ID matches spiffe://penguintech.io/{env}/svc-core
+
+pytest tests/identity/test_svid_required.py -v
+```
+The test must assert a call presenting **no** SVID is rejected, and be made to fail against
+a permissive config first. An mTLS requirement that has never rejected anything is not known
+to require anything.
+
 ### Task 0.4: Propagate tenant scoping into the Python fleet
 
 **Largest single item in P0.** The `tenants` / `tenant_admins` / `tenant_settings` tables and `communities.tenant_id` already exist, and the Node hub resolves tenant context in `middleware/auth.js`. The ~40 Python services do not: 246 files query by `community_id` with no tenant filter, so a community id from a request reaches the database unverified.
@@ -279,6 +330,8 @@ never observed failing is not known to work.
 - gRPC call-site classification reported as three counts against the starting 21.
 - Redelivery, DLQ and idempotency tests pass, each on record as having failed first.
 - Cross-tenant Valkey read returns `NOPERM`, proven by a test that has been made to fail.
+- All seven workloads hold an SVID matching `spiffe://penguintech.io/{env}/{service}`, and a
+  call without one is rejected — proven by a test that has been made to fail.
 - No key path bypasses the tenant segment, including for the default tenant.
 - Cross-tenant isolation test passes, and is on record as having failed against pre-P0 code.
 - Tenant-scoping count reported against the Step 1 denominator, not asserted as "all".
@@ -413,6 +466,7 @@ Customer: accounts, contacts, opportunities. Marketing: scheduling plus basic an
 | 1 | Complete or delete the `services/` tree | all of P0 | 0.1 |
 | 2 | Feature → tier mapping (Free/Pro/Enterprise) | P1 seeding | 1.1 |
 | 3 | `module_rtc`: Rust rewrite or documented Go exception | P3 | P3 entry |
+| 4 | Which SPIRE root per environment — self-signed child, or nested under SkausWatch | nothing; per-env values flip | 0.3c |
 
 ## Notes carried from the v2.2.x review
 

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -8,6 +8,14 @@
 
 **Tech Stack:** Python 3.13/Quart, Helm, PostHog (self-hosted CE), PenguinTech License Server v1.1.x, penguin-libs
 
+**Standing rule — reuse is the default.** v2.2.x carries years of fixes that are invisible
+until missing: tuned healthcheck timings, `securityContext` blocks added after rootless
+failures, retry values from real outages. A restructure is the most efficient way to lose them,
+because nothing fails when a tuned value becomes a plausible default. Move code, do not retype
+it; state a reason in the PR when rewriting rather than reusing; port health checks,
+`securityContext`, resource limits, image digests and timeout/retry policy as an explicit
+checklist item. Where v2.2.x is wrong, fix it *there* rather than carrying the defect forward.
+
 ---
 
 ## How this plan is staged
@@ -392,6 +400,19 @@ pytest tests/streams/test_no_pii_in_envelope.py -v   # assert against a field al
 Write it as an allowlist of permitted envelope fields, not a denylist of PII-looking names —
 a denylist passes for every field nobody thought of.
 
+**Step 2b: Fix the consent-persistence defect in v2.2.x, not in v3.** Consent is never saved
+server-side today and the failure is silent — two stacked faults:
+
+- `CookieConsentContext.jsx` posts the consent object directly; `cookieConsentController`
+  expects `{ preferences: {...} }` and 400s without it.
+- The frontend sends `analytics_cookies` / `functional_cookies` / `marketing_cookies`; the
+  backend reads `preferences.analytics` / `.functional` / `.marketing`, so even wrapped
+  correctly every choice would record as denied.
+
+The 400 is swallowed by `console.debug`. GDPR Art. 7(1) requires being able to *demonstrate*
+consent, and a record that was never written demonstrates nothing. Fix in v2.2.x; add a test
+that asserts a round-trip — accept-all, reload, and the server returns analytics `true`.
+
 **Step 3: Consent-safe flag evaluation.** PostHog is the flag plane *and* an analytics tool,
 initialised from one SDK. Flag evaluation needed to render the product is arguably strictly
 necessary; behavioural analytics is not and needs prior consent.
@@ -405,6 +426,16 @@ browser, while flags still resolve. This is the check a cookie audit runs; run i
 
 **Step 4: SBOM**, if CRA is the Cyber Resilience Act. Generate per image in CI; the digest
 pinning and scanning already in place are the inputs.
+
+**Step 5: Inventory what `hub-webui` already provides and carry it forward** rather than
+rebuilding. Present: cookie banner, preferences modal, cookie policy page, consent context and
+hook, server-side consent record with versioning/expiry/`requiresUpdate`, four correct
+categories, and erasure via `dataPrivacyController.requestDataDeletion`.
+
+Missing, and therefore actual work: **access, correction and portability** (the controller
+exports deletion only), **CCPA/CPRA opt-out and Global Privacy Control**, and **wiring
+analytics to the `analytics` consent category** — the categories exist but nothing consumes
+them to gate PostHog.
 
 
 

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -101,47 +101,65 @@ pytest tests/tenancy/test_cross_tenant_isolation.py -v
 ```
 Write that test so it fails against today's code first. A tenant-isolation test that has never gone red is not evidence of isolation.
 
-### Task 0.5: Restructure Helm into Core + Module sub-charts
+### Task 0.5: Collapse to seven containers (ingest → process → action, plus four)
 
 **Files:**
-- Modify: `k8s/helm/waddlebot/Chart.yaml`
-- Create: `k8s/helm/waddlebot/charts/{core,social,customer,bot,marketing}/`
+- Modify: `k8s/helm/waddlebot/Chart.yaml`, `values.yaml`
+- Create: `k8s/helm/waddlebot/templates/{svc-ingest,svc-process,svc-action,svc-core,hub-api,hub-webui,svc-rtc}.yaml`
+- Delete: the ~40 per-module Deployments they replace
 
-**Step 1:** Core has no `condition` — it is not optional. Each Module sub-chart gets `condition: modules.<name>.enabled`.
+The spine is the pipeline the system already has — `trigger/receiver` → `processing/router`
+→ `action/*` — collapsed from ~40 containers into three, plus four supporting containers.
+Modules are code loaded into these, selected by a values flag; they do not get pods of
+their own. See the design doc's Deployment section for why `svc-core` and `svc-rtc` stay
+separate.
 
-```yaml
-dependencies:
-  - name: core
-    version: "0.1.0"
-  - name: bot
-    version: "0.1.0"
-    condition: modules.bot.enabled
-  - name: social
-    version: "0.1.0"
-    condition: modules.social.enabled
-  - name: customer
-    version: "0.1.0"
-    condition: modules.customer.enabled
-  - name: marketing
-    version: "0.1.0"
-    condition: modules.marketing.enabled
-```
-
-**Step 2:** Default every Module to `enabled: false` in `values.yaml`; enable per environment values file.
-
-**Verify — this gate must be made to fail once before it is trusted:**
+**Step 1: Establish the denominator before deleting anything.**
 ```bash
-# Core alone renders and contains no Module workloads
-helm template waddles ./k8s/helm/waddlebot \
-  --set modules.bot.enabled=false \
-  --set modules.social.enabled=false \
-  --set modules.customer.enabled=false \
-  --set modules.marketing.enabled=false > /tmp/core-only.yaml
-test -s /tmp/core-only.yaml || { echo "FAIL: empty render"; exit 1; }
-grep -c "kind: Deployment" /tmp/core-only.yaml    # must be > 0
-! grep -qE "name: (bot|social|customer|marketing)-" /tmp/core-only.yaml
+grep -rl "kind: Deployment" k8s/helm/waddlebot/templates/ | wc -l   # the "from" number
 ```
-Then deliberately set `modules.bot.enabled=true` and confirm the last assertion fails. A toggle that has never been observed failing is not known to work.
+The final report cites this against the target of 7. "Consolidated the containers" without
+both numbers is not a result.
+
+**Step 2:** Each container reads `modules.<name>.enabled` and loads only the enabled
+Modules' App bundles. A disabled Module's packages must not be imported — verify by absence
+of its import cost, not by absence of its routes.
+
+**Step 3:** Map every existing Deployment to exactly one destination, by pipeline position:
+`trigger/receiver/*` → `svc-ingest`; `processing/*` and the event bus → `svc-process`;
+`action/pushing/*` and `action/interactive/*` → `svc-action`; `core/` identity/security/
+credentials → `svc-core`; `admin/*` → `hub-api`/`hub-webui`; `core/module_rtc` → `svc-rtc`.
+
+A service mapping to none is either Core-with-no-home (fix the mapping) or dead (delete it,
+and say which).
+
+**Step 4:** Port health checks, `securityContext`, resource limits and digest-pinned images
+from the Deployments being retired. Do not re-derive them — the existing ones encode fixes.
+
+**Verify:**
+```bash
+helm template waddles ./k8s/helm/waddlebot > /tmp/all.yaml
+grep -c "kind: Deployment" /tmp/all.yaml          # expect 7
+grep -c "runAsNonRoot: true" /tmp/all.yaml        # expect 7 — rootless is not optional
+helm lint ./k8s/helm/waddlebot
+```
+
+**Step 5: Prove the Module flag does something in *every* stage it touches.**
+
+Modules span stages (Bot is in all three; Customer is mostly `hub-api`), so a flag honoured
+in one container and ignored in another leaves a half-disabled Module — worse than either
+state. Assert per stage, not once:
+
+```bash
+for stage in svc-ingest svc-process svc-action; do
+  helm template waddles ./k8s/helm/waddlebot --set modules.social.enabled=false \
+    | yq "select(.metadata.name == \"$stage\")" \
+    | grep -qi "social" && { echo "FAIL: social bundle still in $stage"; exit 1; }
+done
+```
+
+Run it with the flag ON first and confirm it fails for each stage Social occupies. A toggle
+never observed failing is not known to work.
 
 ### P0 exit gate
 
@@ -150,6 +168,8 @@ Then deliberately set `modules.bot.enabled=true` and confirm the last assertion 
 - Event bus contains no platform-specific vocabulary.
 - Cross-tenant isolation test passes, and is on record as having failed against pre-P0 code.
 - Tenant-scoping count reported against the Step 1 denominator, not asserted as "all".
+- `helm template` renders exactly 7 Deployments, all `runAsNonRoot: true`, reported against
+  the pre-consolidation count.
 
 ---
 
@@ -169,7 +189,9 @@ Which Features are Free / Professional / Enterprise is commercial, not architect
 - Create: `docs/architecture/app-manifest.md`
 - Create: `libs/app_manifest/` (shared validation)
 
-Manifest fields: `id`, `module`, `provides` (versioned Feature contracts), `requires_core`, `requires_scopes`, `min_tier`, `flag`, `vendor`.
+Manifest fields: `id`, `module`, `stages`, `provides` (versioned Feature contracts), `requires_core`, `requires_scopes`, `min_tier`, `flag`, `vendor`.
+
+`stages` lists the pipeline containers that load the App — `ingest`, `process`, `action`, or several. A Module spans stages, so its Apps do too; the stage is what tells a container whether a given App is its concern. Validate that a declared stage exists and that a third-party App declares exactly one (it is invoked over the network, not loaded).
 
 `provides` entries are versioned — `bot.shoutout@1`. Ship no unversioned contract; once a third-party App binds to a Feature, the interface is public API and an unversioned one cannot be changed safely.
 

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -294,6 +294,8 @@ Adopt `skauswatch-auth`'s ordering contract verbatim: **tenant → scope → fea
 
 **Step 4: Scope at the ORM layer**, not per call site. A helper that takes the tenant from request context and constrains the query is the only correct shape — 246 hand-written filters will not stay correct.
 
+No shortcut for the single-tenant case. Free and Professional are permanently capped at the default tenant, so a `if tenant == "default": skip_filter()` fast path would leave the multi-tenant branch untested in almost every deployment — and only Enterprise customers would find the bugs. Single-tenant runs the identical code with N=1.
+
 **Step 5: Rework roles into per-level scope bundles.** `setup_default_roles` currently defines four global roles and grants `admin` the unbounded `['*']`. Replace with bundles at global / tenant / community level, per the `security.md` bundle table. Middleware checks scopes, never role names.
 
 **Verify — make it fail on purpose before trusting it:**
@@ -454,7 +456,23 @@ proposes that split; get it confirmed rather than assuming it.
 level of `global → tenant → community`. Raise the mismatch with the license-server team;
 do not resolve it locally by adopting the colliding name.
 
-**Step 3:** Carry the confirmed mapping into `seeds/waddles.py` in Task 1.4.
+**Step 3: Model the two structural caps** — they limit how many of a thing exists, not what
+it can do, so they are not plain boolean features:
+
+| Cap | Free | Professional | Enterprise |
+|-----|------|--------------|------------|
+| Admins | 1 | many | many |
+| Tenants | 1 (default) | 1 (default) | many |
+
+Enforce tenant creation the way `critical-rules.md` enforces **seats**, not nodes: block
+creation of a second tenant with an upgrade path, and never touch the existing one. Tenant
+creation is a deliberate administrative act, so blocking it is safe.
+
+**Test:** on a Free or Professional licence, creating a second tenant is refused with an
+upgrade path, and the existing tenant keeps working throughout. Write it so it fails against
+an unenforced cap first.
+
+**Step 4:** Carry the confirmed mapping into `seeds/waddles.py` in Task 1.4.
 
 ### Task 1.2: Define the App manifest schema
 

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -1,0 +1,287 @@
+# v3.0.x SCBM Module + App Migration Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate Waddles from ~40 co-equal service containers to Core → Modules → Features → Apps, reaching v2.2.x feature parity at v3.0.0 with lightweight Customer and Marketing.
+
+**Architecture:** See `2026-08-26-v3-scbm-apps-design.md`. Core is mandatory; Modules (Social, Customer, Bot, Marketing) toggle globally via Helm; Features are contracts gated by license tier × PostHog flag; Apps implement Features and bind per tenant/community through the marketplace.
+
+**Tech Stack:** Python 3.13/Quart, Helm, PostHog (self-hosted CE), PenguinTech License Server v1.1.x, penguin-libs
+
+---
+
+## How this plan is staged
+
+P0 and P1 are specified task-by-task. **P2–P5 are specified as outcomes and exit gates only** — their task detail depends on decisions and interfaces that P0/P1 produce, and writing it now would be speculation. Each of P2–P5 gets its own plan document when its predecessor's exit gate is met.
+
+Three decisions block work and are called out as tasks rather than assumed.
+
+---
+
+## Phase 0 — Extract Core
+
+### Task 0.1: Resolve the `services/` tree (DECISION REQUIRED)
+
+**Blocks:** everything in P0 onward.
+
+`services/` is a half-finished consolidation. `docs/MODULE_CANONICAL_SOURCES.md` documents that `services/interactive-social/{alias,shoutout,presence}_interaction_module/` are orphaned duplicates that have *diverged* from the canonical `action/interactive/` copies — they carry newer component-based DB/Redis config that was never ported back.
+
+Present the options to the human and get an explicit answer:
+
+- **Complete it** — finish moving every module into `services/` groupings, delete `action/`, `core/`, `trigger/`, `processing/`. Larger move, but the grouping survives into v3 as the Module boundary.
+- **Delete it** — remove `services/`, keep the `action/`/`core/`/`trigger/` trees, and let v3's Module boundaries replace the grouping entirely.
+
+**Do not proceed until answered.** Converting Apps against two divergent trees will silently pick the wrong copy — that is exactly the failure `MODULE_CANONICAL_SOURCES.md` was written to prevent.
+
+**Step 1:** Before presenting, port the diverged config improvements out of the orphaned copies so the decision does not destroy work:
+```bash
+diff -ru action/interactive/presence_module services/interactive-social/presence_module
+diff -ru action/interactive/alias_interaction_module services/interactive-social/alias_interaction_module
+diff -ru action/interactive/shoutout_interaction_module services/interactive-social/shoutout_interaction_module
+```
+Capture anything worth keeping in a scratch patch and state that in the decision request.
+
+### Task 0.2: Inventory the Core boundary
+
+**Files:**
+- Create: `docs/architecture/core-boundary.md`
+
+Apply one test to every existing service: **does more than one Module need it?** If yes it is Core; if exactly one, it belongs to that Module.
+
+Produce a table with a column for the *evidence* — which Modules need it and why. A service assigned to Core without two named consumers is a mistake; record it as Module-owned instead.
+
+Expected Core set (verify, do not assume): identity, security, credentials, tenancy/community, event bus, workflow, analytics, marketplace, hub.
+
+Expected Module-owned but currently sitting in `core/`: `browser_source_core_module` and `video_proxy_module` (Social only), `engagement_module` (Marketing only), `reputation_module` and `labels_core_module` (verify — likely Social + Bot, therefore Core).
+
+### Task 0.3: Split the router
+
+**Files:**
+- Create: `core/event_bus_module/`
+- Modify: `processing/router_module/`
+
+**Step 1:** Identify the split line. In `processing/router_module/services/`, generic routing and pub/sub move to the event bus; `command_registry.py`, cooldown handling, and emote services stay with Bot.
+
+**Step 2:** The event bus exposes publish/subscribe over gRPC (port 50051, `api_version` field per `backend.md`) with no Twitch/Discord vocabulary in its interface. If a Customer-module developer reading the event bus API sees the word "command" or "emote", the split is wrong.
+
+**Step 3:** Bot's command dispatch becomes a *consumer* of the event bus, not a peer of it.
+
+**Verify:** `grep -riE "twitch|discord|emote|command" core/event_bus_module/ --include=*.py` returns nothing outside comments.
+
+### Task 0.4: Propagate tenant scoping into the Python fleet
+
+**Largest single item in P0.** The `tenants` / `tenant_admins` / `tenant_settings` tables and `communities.tenant_id` already exist, and the Node hub resolves tenant context in `middleware/auth.js`. The ~40 Python services do not: 246 files query by `community_id` with no tenant filter, so a community id from a request reaches the database unverified.
+
+Everything downstream — Feature gating, App binding, marketplace installs — assumes a trustworthy tenant claim. None of it is sound until this lands.
+
+**Files:**
+- Modify: `libs/flask_core/flask_core/auth.py`
+- Create: `libs/flask_core/flask_core/tenancy.py`
+- Modify: all services reaching `community_id` (enumerate; do not estimate)
+
+**Step 1: Enumerate the real scope, with a count.**
+```bash
+grep -rl "community_id" --include="*.py" . | grep -v node_modules | grep -v .worktrees | sort > /tmp/tenant-scope.txt
+wc -l < /tmp/tenant-scope.txt   # assert non-zero; this is the denominator
+```
+A later "all done" claim must cite this number. Zero files examined is a failure, not a pass.
+
+**Step 2: Add the `tenant` claim** to `create_jwt_token`/`verify_jwt_token`. Per `security.md` the claim is mandatory on every token — reject tokens without it rather than defaulting.
+
+**Step 3: Tenant middleware runs first**, before scope checks. Mismatch is 403. The client cannot set tenant; it comes from the validated JWT only.
+
+**Step 4: Scope at the ORM layer**, not per call site. A helper that takes the tenant from request context and constrains the query is the only correct shape — 246 hand-written filters will not stay correct.
+
+**Step 5: Rework roles into per-level scope bundles.** `setup_default_roles` currently defines four global roles and grants `admin` the unbounded `['*']`. Replace with bundles at global / tenant / community level, per the `security.md` bundle table. Middleware checks scopes, never role names.
+
+**Verify — make it fail on purpose before trusting it:**
+```bash
+# A token for tenant A must not reach a community owned by tenant B
+pytest tests/tenancy/test_cross_tenant_isolation.py -v
+```
+Write that test so it fails against today's code first. A tenant-isolation test that has never gone red is not evidence of isolation.
+
+### Task 0.5: Restructure Helm into Core + Module sub-charts
+
+**Files:**
+- Modify: `k8s/helm/waddlebot/Chart.yaml`
+- Create: `k8s/helm/waddlebot/charts/{core,social,customer,bot,marketing}/`
+
+**Step 1:** Core has no `condition` — it is not optional. Each Module sub-chart gets `condition: modules.<name>.enabled`.
+
+```yaml
+dependencies:
+  - name: core
+    version: "0.1.0"
+  - name: bot
+    version: "0.1.0"
+    condition: modules.bot.enabled
+  - name: social
+    version: "0.1.0"
+    condition: modules.social.enabled
+  - name: customer
+    version: "0.1.0"
+    condition: modules.customer.enabled
+  - name: marketing
+    version: "0.1.0"
+    condition: modules.marketing.enabled
+```
+
+**Step 2:** Default every Module to `enabled: false` in `values.yaml`; enable per environment values file.
+
+**Verify — this gate must be made to fail once before it is trusted:**
+```bash
+# Core alone renders and contains no Module workloads
+helm template waddles ./k8s/helm/waddlebot \
+  --set modules.bot.enabled=false \
+  --set modules.social.enabled=false \
+  --set modules.customer.enabled=false \
+  --set modules.marketing.enabled=false > /tmp/core-only.yaml
+test -s /tmp/core-only.yaml || { echo "FAIL: empty render"; exit 1; }
+grep -c "kind: Deployment" /tmp/core-only.yaml    # must be > 0
+! grep -qE "name: (bot|social|customer|marketing)-" /tmp/core-only.yaml
+```
+Then deliberately set `modules.bot.enabled=true` and confirm the last assertion fails. A toggle that has never been observed failing is not known to work.
+
+### P0 exit gate
+
+- One module tree only; `MODULE_CANONICAL_SOURCES.md` deleted or reduced to history.
+- Core deploys with all four Modules off, and the render is verified non-empty.
+- Event bus contains no platform-specific vocabulary.
+- Cross-tenant isolation test passes, and is on record as having failed against pre-P0 code.
+- Tenant-scoping count reported against the Step 1 denominator, not asserted as "all".
+
+---
+
+## Phase 1 — App registry and binding
+
+This is the architecturally novel phase. Everything after it is conversion work.
+
+### Task 1.1: Set the tier mapping (DECISION REQUIRED)
+
+**Blocks:** Task 1.4.
+
+Which Features are Free / Professional / Enterprise is commercial, not architectural. Present the Feature list from P0's inventory and get the mapping. Reference the tier sizing in `critical-rules.md`; note Free is capped at 1 admin, which constrains anything multi-admin.
+
+### Task 1.2: Define the App manifest schema
+
+**Files:**
+- Create: `docs/architecture/app-manifest.md`
+- Create: `libs/app_manifest/` (shared validation)
+
+Manifest fields: `id`, `module`, `provides` (versioned Feature contracts), `requires_core`, `requires_scopes`, `min_tier`, `flag`, `vendor`.
+
+`provides` entries are versioned — `bot.shoutout@1`. Ship no unversioned contract; once a third-party App binds to a Feature, the interface is public API and an unversioned one cannot be changed safely.
+
+`requires_scopes` is validated against the Feature contract at install time, not at call time. An App may request a **subset** of the scopes its Feature declares; requesting anything outside that set fails the install. Installing a third-party App must never be a privilege-escalation path.
+
+**Test:** an App manifest declaring a scope its Feature does not grant is rejected at install, and the rejection names the offending scope.
+
+### Task 1.3: Rename installations and add tenant scope
+
+**Files:**
+- Create: `alembic/versions/<rev>_app_installations.py`
+- Modify: `admin/hub_module/backend/src/controllers/marketplaceController.js`
+- Modify: `admin/marketplace_module/backend/src/controllers/installationController.js`
+
+**Step 1:** Rename `hub_module_installations` → `app_installations`. Column semantics are unchanged; the name stops meaning three things.
+
+**Step 2:** Add nullable `tenant_id`. A row with `tenant_id` set and `community_id` null is a tenant-scope binding; both set is community scope.
+
+**Step 3:** Add the binding resolution query — narrowest wins:
+```sql
+-- community binding → tenant binding → shipped default
+SELECT app_id FROM app_installations
+WHERE feature = $1
+  AND (community_id = $2 OR (community_id IS NULL AND tenant_id = $3))
+ORDER BY community_id NULLS LAST
+LIMIT 1;
+```
+When this returns no row, the caller uses the Module's shipped default App. There is deliberately no platform-scope row — the default is code, not data, so every deployment keeps a known-good baseline.
+
+**Test:** resolution order is the thing most likely to break silently. Cover: community override present; tenant override only; neither (falls to default); both present (community wins); community row for a *different* community (must not leak).
+
+### Task 1.4: Seed the Waddles product in license-server
+
+**Files:**
+- Create: `api/app/seeds/waddles.py` in `~/code/license-server`
+- Create: `api/app/seeds/waddles_seed.py`
+- Create: `api/seed_waddles_product.py`
+
+Mirror `api/app/seeds/waddleai.py` exactly — it is the working reference for this shape. Each Feature carries `tier_requirements` per tier plus `default_entitled`; flag keys are namespaced `waddles.<module>.<feature>` so a Module's flags are greppable as a set.
+
+Note the WaddleAI seed's docstring warning: `seed_db.py`/`seed_test_data.py` are broken against the pinned penguin-dal because they never run `app.startup()`. Follow `seed_waddleai_product.py`'s pattern, not theirs.
+
+### Task 1.5: Build the entitlement client
+
+**Files:**
+- Create: `libs/entitlement/`
+
+Two gates, both must pass: license tier entitles the Feature **and** its PostHog flag evaluates true for the tenant.
+
+Degradation rules, which are the part that gets this wrong in production:
+- either service unreachable → last-known cached value
+- a flag never seen before → OFF, never open
+- never crash a request path on an entitlement lookup
+
+**Test:** simulate both services down with a warm cache, and with a cold cache. Cold cache plus unknown flag must resolve OFF.
+
+### Task 1.6: Convert three Bot units as proof
+
+Pick three with different shapes: one interaction (`shoutout`), one trigger (`twitch`), one action (`discord`).
+
+**Exit criterion for the whole phase:** a community admin can rebind `bot.shoutout` from `shoutout-default` to a second App and observe the change take effect, without a deploy and without affecting any other community.
+
+### P1 exit gate
+
+- Binding resolution passes its five-case test suite.
+- The rebind demo works end to end for one Feature.
+- `waddles` product seeded; entitlement client degrades correctly with services down.
+
+---
+
+## Phases 2–5 — outcomes and gates
+
+Task detail for each is written when its predecessor's gate is met.
+
+### P2 — Bot as Apps
+
+Convert all `trigger/receiver/*`, `action/pushing/*`, `action/interactive/*` units to Apps.
+
+**Gate:** v2.2.x Bot functionality reachable entirely through Feature bindings; no privileged built-in path remains. Regression suite from v2.2.x passes against the App-routed implementation.
+
+### P3 — Social as Apps
+
+Convert `community_module`, `presence`, `alias`, `quote`, `shoutout`, `video_proxy`, `browser_source_core`. **Blocked by the `module_rtc` decision** — it is Go, and Social's conferencing story is where it would grow, which the Go phase-out rule forbids. Rewrite in Rust or grant a documented exception before starting.
+
+**Gate:** v2.2.x Social functionality reachable through Feature bindings; chat and communities usable without Bot deployed.
+
+### P4 — Customer and Marketing, lightweight
+
+Customer: accounts, contacts, opportunities. Marketing: scheduling plus basic analytics, seeded from `engagement_module`.
+
+**Scope is fixed here.** Customer is a full CRM eventually and Marketing a full suite; neither is in v3.0.0. Anything beyond the listed entities is 3.x with its own spec.
+
+**Gate:** both Modules deploy, toggle globally, and expose at least one rebindable Feature each — proving the pattern holds for green-field Modules, not just converted ones.
+
+### P5 — Cut v3.0.0
+
+**Gate:** parity verified against v2.2.x with a documented comparison, not an assertion. Every Module toggles off cleanly. Upgrade path from v2.2.x exercised on gamma per `deploying-app`.
+
+---
+
+## Open decisions summary
+
+| # | Decision | Blocks | Task |
+|---|----------|--------|------|
+| 1 | Complete or delete the `services/` tree | all of P0 | 0.1 |
+| 2 | Feature → tier mapping (Free/Pro/Enterprise) | P1 seeding | 1.1 |
+| 3 | `module_rtc`: Rust rewrite or documented Go exception | P3 | P3 entry |
+
+## Notes carried from the v2.2.x review
+
+Surfaced while fixing PR #154; they affect migration work and are not yet resolved:
+
+- `make lint` and `make test-security` wrap every tool in `|| true` and cannot fail. Any phase relying on them for verification is relying on nothing.
+- The pre-commit hook calls `pre-commit hook-impl --config=.pre-commit-config.yaml`, and that file is absent — the hook blocks every commit rather than gating it.
+- 10 unhashed requirement files carry known CVEs; `botbuilder-adapters-teams>=4.14.0` does not exist on PyPI, so both teams receiver images cannot build.

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -205,6 +205,15 @@ entries per `penguintech.md`: `spiffe://penguintech.io/{env}/{service}` for each
 X.509-SVID as a first-class identity mechanism whether or not SPIRE runs in that
 environment, so enabling it elsewhere is configuration rather than a rewrite.
 
+**Step 3b: Verify the *peer's* SVID, not just present your own.** Mirror
+`skauswatch-identity`'s split — an identity provider that attests to the Workload API socket
+(`SPIFFE_ENDPOINT_SOCKET`) and holds the SVID plus trust bundles, and a **matcher enforcing a
+per-service allowlist of accepted peer SPIFFE IDs**.
+
+Without the matcher, mTLS proves only that the peer holds *some* valid SVID in the trust
+domain, so every workload in the mesh passes. Declare the accepted peers per service —
+`svc-core` accepts the three stages, not anything holding a `penguintech.io` SVID.
+
 **Step 4: mTLS does not replace the JWT.** Per `security.md`, every inter-service call
 carries a short-lived signed JWT regardless of transport. Apply to both remaining call
 shapes: stage → `svc-core` gRPC, and stage → Valkey (client-cert TLS).
@@ -222,9 +231,10 @@ kubectl exec -n waddles deploy/svc-core -- \
 
 pytest tests/identity/test_svid_required.py -v
 ```
-The test must assert a call presenting **no** SVID is rejected, and be made to fail against
-a permissive config first. An mTLS requirement that has never rejected anything is not known
-to require anything.
+Two assertions, both made to fail against a permissive config first: a call presenting **no**
+SVID is rejected, and a call presenting a **valid SVID that is not on the callee's allowlist**
+is also rejected. The second is the one that catches a missing matcher — an mTLS requirement
+that has never rejected a legitimately-issued identity is not known to authorize anything.
 
 ### Task 0.4: Propagate tenant scoping into the Python fleet
 
@@ -249,6 +259,8 @@ A later "all done" claim must cite this number. Zero files examined is a failure
 Existing tokens carry no tenant. Issue them as the **default tenant** during the migration window, and reject unclaimed tokens once that window closes — a permanent "missing means default" fallback is the untenanted backdoor in a different shape. Set and record the cutoff date.
 
 **Step 3: Tenant middleware runs first**, before scope checks. Mismatch is 403. The client cannot set tenant; it comes from the validated JWT only.
+
+Adopt `skauswatch-auth`'s ordering contract verbatim: **tenant → scope → feature/licensing**. Assert it with a test that reverses the layers and confirms the reversal is caught, because ordering bugs are invisible in the happy path — a scope check against an unverified tenant returns the right answer to the wrong question.
 
 **Step 4: Scope at the ORM layer**, not per call site. A helper that takes the tenant from request context and constrains the query is the only correct shape — 246 hand-written filters will not stay correct.
 

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -153,7 +153,7 @@ dedupe path is a duplicate-post bug waiting for its first redelivery.
 **Verify — prove redelivery and the DLQ actually work:**
 ```bash
 pytest tests/streams/test_redelivery.py -v      # kill a consumer mid-ack; event must redeliver
-pytest tests/streams/test_dlq.py -v             # poison event lands in waddles.dlq, not retried forever
+pytest tests/streams/test_dlq.py -v             # poison lands in waddles:t:{tenant}:dlq, not retried forever
 pytest tests/streams/test_idempotency.py -v     # same envelope id twice = one effect
 ```
 Write each so it fails first. A redelivery test that has never gone red proves nothing.
@@ -168,7 +168,7 @@ Write each so it fails first. A redelivery test that has never gone red proves n
 putting a gRPC service in front of Valkey adds a hop and a failure domain for nothing.
 
 **Step 2:** `command_registry.py`, cooldown handling and emote services stay with Bot, as a
-consumer of `waddles.process`.
+consumer of `waddles:t:{tenant}:process`.
 
 **Step 3:** No Twitch/Discord vocabulary may appear in the shared library. If a
 Customer-module developer reading it sees "command" or "emote", the split is wrong.

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -20,26 +20,56 @@ Three decisions block work and are called out as tasks rather than assumed.
 
 ## Phase 0 — Extract Core
 
-### Task 0.1: Resolve the `services/` tree (DECISION REQUIRED)
+### Task 0.1: Split `services/` into its dead half and its useful half
 
-**Blocks:** everything in P0 onward.
+**Decided:** delete once we have confirmed nothing still needs it. Analysis shows the tree is
+two very different things, and the confirmation is available now by proof rather than by
+waiting for parity.
 
-`services/` is a half-finished consolidation. `docs/MODULE_CANONICAL_SOURCES.md` documents that `services/interactive-social/{alias,shoutout,presence}_interaction_module/` are orphaned duplicates that have *diverged* from the canonical `action/interactive/` copies — they carry newer component-based DB/Redis config that was never ported back.
+| Part | Files | State |
+|------|-------|-------|
+| 21 `*_module/` subdirectories | all of them | **provably dead** — every one is shadowed at build time by a `COPY` from the canonical tree, or never copied at all |
+| 11 aggregator `app.py` + `config.py` + `requirements.txt` | the rest | **live and valuable** — each merges several modules into one Quart app |
 
-Present the options to the human and get an explicit answer:
+`docs/MODULE_CANONICAL_SOURCES.md` documents **3** orphans. The real number is **21**. Every
+`services/*/Dockerfile` copies module code from `action/`, `core/`, `trigger/` or
+`processing/` and overwrites the local subdirectory of the same name.
 
-- **Complete it** — finish moving every module into `services/` groupings, delete `action/`, `core/`, `trigger/`, `processing/`. Larger move, but the grouping survives into v3 as the Module boundary.
-- **Delete it** — remove `services/`, keep the `action/`/`core/`/`trigger/` trees, and let v3's Module boundaries replace the grouping entirely.
-
-**Do not proceed until answered.** Converting Apps against two divergent trees will silently pick the wrong copy — that is exactly the failure `MODULE_CANONICAL_SOURCES.md` was written to prevent.
-
-**Step 1:** Before presenting, port the diverged config improvements out of the orphaned copies so the decision does not destroy work:
+**Step 1: Prove it, do not trust this table.** Regenerate the analysis and report the count:
 ```bash
-diff -ru action/interactive/presence_module services/interactive-social/presence_module
-diff -ru action/interactive/alias_interaction_module services/interactive-social/alias_interaction_module
-diff -ru action/interactive/shoutout_interaction_module services/interactive-social/shoutout_interaction_module
+for d in services/*/; do g=$(basename "$d")
+  for sub in "$d"*_module*/; do [ -d "$sub" ] || continue; m=$(basename "$sub")
+    grep -qE "^COPY( --[a-z=:]+)* +services/$g/$m" "$d/Dockerfile" \
+      && echo "LIVE $g/$m" || echo "DEAD $g/$m"
+  done
+done | sort | uniq -c
 ```
-Capture anything worth keeping in a scratch patch and state that in the decision request.
+Any `LIVE` result contradicts this task and must stop it — that subdirectory is a real build
+input and deleting it would break a container.
+
+**Step 2: Port the diverged config before deleting.** The `interactive-social` orphans carry
+newer component-based DB/Redis config that was never ported back:
+```bash
+for m in presence_module alias_interaction_module shoutout_interaction_module; do
+  diff -ru "action/interactive/$m" "services/interactive-social/$m" || true
+done
+```
+Check the other 18 the same way — `MODULE_CANONICAL_SOURCES.md` only examined three, so
+assume nothing about the rest. Report what was ported and what was discarded; "nothing worth
+keeping" is a finding that needs stating, not an empty result.
+
+**Step 3: Delete the 21 orphaned subdirectories.** Nothing builds from them, so this is not
+a parity risk. Verify every image still builds afterwards.
+
+**Step 4: Keep the aggregators — they are the prototype for Task 0.5.**
+`services/interactive-social/app.py` is 846 lines that already merge four modules into one
+Quart app, mounting each module's blueprints. That is precisely what `svc-ingest`,
+`svc-process` and `svc-action` need to do. Harvest the pattern rather than reinventing it;
+note that it leans on `sys.path.insert` to import, which the consolidation should replace
+with real packaging.
+
+**Step 5:** Replace `docs/MODULE_CANONICAL_SOURCES.md` with a note that the orphans are gone
+and the aggregators are superseded at P5, when `services/` itself is removed.
 
 ### Task 0.2: Inventory the Core boundary
 
@@ -384,7 +414,7 @@ Report pages deleted alongside pages written.
 
 ### P0 exit gate
 
-- One module tree only; `MODULE_CANONICAL_SOURCES.md` deleted or reduced to history.
+- All 21 orphaned `services/*/*_module/` subdirectories deleted, diverged config ported out first and the port reported; every image still builds; `MODULE_CANONICAL_SOURCES.md` replaced.
 - Core deploys with all four Modules off, and the render is verified non-empty.
 - Event bus library contains no platform-specific vocabulary.
 - Zero Alpine and zero unpinned images in `k8s/`; Valkey and Postgres bookworm, digest-pinned.
@@ -408,11 +438,23 @@ Report pages deleted alongside pages written.
 
 This is the architecturally novel phase. Everything after it is conversion work.
 
-### Task 1.1: Set the tier mapping (DECISION REQUIRED)
+### Task 1.1: Confirm the tier mapping, then seed it
 
-**Blocks:** Task 1.4.
+**Mostly decided.** The design doc's tier table derives the mapping from `critical-rules.md`
+and what v2.2.x already gates. One residual question needs a commercial answer before seeding.
 
-Which Features are Free / Professional / Enterprise is commercial, not architectural. Present the Feature list from P0's inventory and get the mapping. Reference the tier sizing in `critical-rules.md`; note Free is capped at 1 admin, which constrains anything multi-admin.
+**Step 1: Settle the two-tier to three-tier split.** v2.2.x is effectively two-tier — free vs
+`premium`, with 83 `premium` references and `PREMIUM_BYPASS_DOMAINS`. Every capability
+currently marked `premium` has to land in Professional *or* Enterprise. The design doc
+proposes that split; get it confirmed rather than assuming it.
+
+**Step 2: Use `free`, not `community`, as the tier name.** The license server's enum is
+`("community", "professional", "enterprise")` while `critical-rules.md` names the tier
+**Free**. Waddles cannot adopt `community` — it is a first-class entity here, the team/org
+level of `global → tenant → community`. Raise the mismatch with the license-server team;
+do not resolve it locally by adopting the colliding name.
+
+**Step 3:** Carry the confirmed mapping into `seeds/waddles.py` in Task 1.4.
 
 ### Task 1.2: Define the App manifest schema
 
@@ -505,7 +547,7 @@ Convert all `trigger/receiver/*`, `action/pushing/*`, `action/interactive/*` uni
 
 ### P3 — Social as Apps
 
-Convert `community_module`, `presence`, `alias`, `quote`, `shoutout`, `video_proxy`, `browser_source_core`. **Blocked by the `module_rtc` decision** — it is Go, and Social's conferencing story is where it would grow, which the Go phase-out rule forbids. Rewrite in Rust or grant a documented exception before starting.
+Convert `community_module`, `presence`, `alias`, `quote`, `shoutout`, `video_proxy`, `browser_source_core`. **`module_rtc` is rewritten in Rust** in this phase, per the Go phase-out rule — decided, no longer a blocker. It stays `svc-rtc` regardless, since UDP media transport cannot share a pod with the HTTP stages.
 
 **Gate:** v2.2.x Social functionality reachable through Feature bindings; chat and communities usable without Bot deployed. Social's Feature pages written, its per-module docs deleted, budget lowered.
 
@@ -519,18 +561,20 @@ Customer: accounts, contacts, opportunities. Marketing: scheduling plus basic an
 
 ### P5 — Cut v3.0.0
 
-**Gate:** parity verified against v2.2.x with a documented comparison, not an assertion. Every Module toggles off cleanly. Upgrade path from v2.2.x exercised on gamma per `deploying-app`. `README.md` and `docs/index.md` rewritten; dead-reference budget is **zero**.
+Delete what remains of `services/` — the 11 aggregators, superseded by the seven container templates from Task 0.5. This is the phase where parity is confirmed, which is the condition for removing them.
+
+**Gate:** parity verified against v2.2.x with a documented comparison, not an assertion. `services/` fully removed, its aggregators superseded by the seven container templates. Every Module toggles off cleanly. Upgrade path from v2.2.x exercised on gamma per `deploying-app`. `README.md` and `docs/index.md` rewritten; dead-reference budget is **zero**.
 
 ---
 
 ## Open decisions summary
 
-| # | Decision | Blocks | Task |
-|---|----------|--------|------|
-| 1 | Complete or delete the `services/` tree | all of P0 | 0.1 |
-| 2 | Feature → tier mapping (Free/Pro/Enterprise) | P1 seeding | 1.1 |
-| 3 | `module_rtc`: Rust rewrite or documented Go exception | P3 | P3 entry |
-| 4 | Which SPIRE root per environment — self-signed child, or nested under SkausWatch | nothing; per-env values flip | 0.3c |
+| # | Decision | Status |
+|---|----------|--------|
+| 1 | `services/` tree | **Resolved** — 21 provably-dead module subdirs deleted in P0; the 11 live aggregators harvested for Task 0.5 and removed at P5 once parity is confirmed |
+| 2 | `module_rtc` language | **Resolved** — rewritten in Rust during P3 |
+| 3 | Feature → tier mapping | **Mostly resolved** — derived in the design doc; the two-tier to three-tier split of v2.2.x's `premium` capabilities needs commercial confirmation before Task 1.4 |
+| 4 | SPIRE root per environment | Open, blocks nothing — a per-env values flip |
 
 ## Notes carried from the v2.2.x review
 


### PR DESCRIPTION
Adds the v3.0.x architecture design and phased migration plan to `docs/plans/`, following the existing design+plan convention.

Docs-only — no code, no CI behaviour, no UI. Screenshot gate is N/A.

## What lands

| File | Contents |
|---|---|
| `2026-08-26-v3-scbm-apps-design.md` | The architecture |
| `2026-08-26-v3-scbm-apps.md` | Phased migration plan; P0/P1 task-by-task, P2–P5 as outcomes and exit gates |

## The model

```
Core / shared services     always on
      ↓
Module                     Social · Customer · Bot · Marketing    — ON/OFF globally
      ↓
Feature                    a versioned contract                   — licence tier × PostHog flag, per tenant
      ↓
App                        the implementation                     — bound per tenant and/or community
```

Nextcloud's model: first-party defaults ship as Apps too, so the extension point is real rather than nominal. Deployment collapses to seven containers along an `ingest → process → action` pipeline, joined by Valkey Streams consumer groups, with per-tenant key namespaces and ACL users. SPIFFE/SPIRE workload identity deploys as a `child` with the upstream disabled, so nesting under SkausWatch later is a values flip rather than a topology change.

v3.0.0 targets v2.2.x parity (Social + Bot fully populated) plus lightweight Customer and Marketing.

## Findings recorded while grounding the design

These came out of reading the current tree, and shaped the plan rather than being discovered mid-migration:

- The `global → tenant → community` ladder exists in the schema and the Node hub, but the ~40 Python services are tenant-blind — 246 files query `community_id` with no tenant filter. Largest P0 item.
- `services/` is two things: 21 provably-dead module subdirectories (each shadowed at build time by a `COPY` from the canonical tree) and 11 live aggregators that are the prototype for the seven containers. `MODULE_CANONICAL_SOURCES.md` documents 3 of the 21.
- `flask_core.stream_pipeline` already implements the Streams pattern but exactly one service uses it, behind an off-by-default flag.
- Eight manifest entries break the base-image rules — `redis:7-alpine` ×4 and `postgres:15/16-alpine` ×4.
- 26 of 61 repository paths referenced in `docs/` no longer exist, and there is no docs check in CI.

## Decisions captured

Resolved: `services/` deleted in two parts; `module_rtc` rewritten in Rust at P3; tier mapping derived from `critical-rules.md` and what v2.2.x already gates. Open: the two-tier → three-tier split of v2.2.x's `premium` capabilities, and which SPIRE root per environment.
