### PR TITLE
chore: make make-lint and make-test-security able to fail

### DIFF
--- a/.checks-baseline
+++ b/.checks-baseline
@@ -1,0 +1,37 @@
+# Frozen pre-existing finding counts, per check.
+#
+# These gates were previously wrapped in `|| true` and could not fail, so the
+# backlog below accumulated unseen. The numbers are a ceiling, not a target:
+# a new finding fails the build, and any run that comes in under its baseline
+# prints a RATCHET line telling you to lower it in the same PR.
+#
+# Never raise a number to make a build pass. If a change genuinely needs to,
+# that is a conversation, not an edit.
+#
+# Seeded 2026-08-26 on release/v3.0.X.
+flake8=2250
+shellcheck=6281
+hadolint=142
+golangci-lint=27
+zizmor=21
+
+# --- security ---
+bandit=0
+pip-audit=0
+npm-audit=0
+gosec=0
+# core/module_rtc only; disappears with the Rust rewrite at P3.
+govulncheck=2
+# gitleaks scans git HISTORY, so this count cannot fall without rewriting it —
+# the RATCHET line will never fire for this check. Baselined so a NEW committed
+# secret fails the gate, which is the property that matters.
+#
+# The 420 are pre-existing and were triaged, not waved through:
+#   208  curl-auth-header   docs/*.md — `curl -H "Authorization: Bearer …"` examples
+#   196  generic-api-key    same, plus k8s/manifests/secrets.yaml
+#    77  of those in k8s/manifests/secrets.yaml, a dev-defaults file whose values
+#        carry placeholder/replace/change markers and which was removed from the
+#        tree in fa7bad03. Still in history; a separate cleanup decision.
+# Per devops.md the pre-commit hook should use `gitleaks protect --staged`,
+# which checks what you are about to commit rather than all of history.
+gitleaks=420

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,7 @@ docker-push:
 	$(error docker-push is CI-only — beta/prod images built by GitHub Actions from release branches)
 
 lint:
-	@echo "=== Linting ==="
-	@if command -v flake8 >/dev/null 2>&1; then echo "-- flake8 --"; python3 -m flake8 . --max-line-length=120 --exclude=.git,__pycache__,venv,node_modules || true; fi
-	@if command -v black >/dev/null 2>&1; then echo "-- black --"; black --check . --exclude '/(\.git|venv|__pycache__|node_modules)/' || true; fi
-	@if command -v isort >/dev/null 2>&1; then echo "-- isort --"; isort --check-only . || true; fi
-	@if command -v mypy >/dev/null 2>&1; then echo "-- mypy --"; python3 -m mypy . --ignore-missing-imports || true; fi
-	@if command -v golangci-lint >/dev/null 2>&1; then echo "-- golangci-lint --"; find . -name "go.mod" -not -path "*/.git/*" -not -path "*/vendor/*" | xargs -I{} dirname {} | xargs -I{} sh -c 'cd {} && golangci-lint run || true'; fi
-	@if command -v hadolint >/dev/null 2>&1; then echo "-- hadolint --"; find . -name "Dockerfile*" -not -path "*/.git/*" | xargs hadolint || true; fi
-	@if command -v shellcheck >/dev/null 2>&1; then echo "-- shellcheck --"; find . -name "*.sh" -not -path "*/.git/*" | xargs shellcheck || true; fi
+	@bash scripts/lint.sh
 
 test:
 	@$(MAKE) test-unit
@@ -44,13 +37,7 @@ test-functional:
 	$(error test-functional is not yet implemented — add pytest tests/functional/ -v after creating tests/functional directory)
 
 test-security:
-	@echo "=== Security Scans ==="
-	@if command -v bandit >/dev/null 2>&1; then echo "-- bandit --"; bandit -r . -x ./tests,./venv,./.git --quiet || true; fi
-	@if command -v pip-audit >/dev/null 2>&1; then echo "-- pip-audit --"; find . -name "requirements.txt" -not -path "*/.git/*" -not -path "*/venv/*" | xargs -I{} pip-audit -r {} 2>/dev/null || true; fi
-	@if command -v gosec >/dev/null 2>&1; then echo "-- gosec --"; find . -name "go.mod" -not -path "*/.git/*" -not -path "*/vendor/*" | xargs -I{} dirname {} | xargs -I{} sh -c 'cd {} && gosec ./... || true'; fi
-	@if command -v govulncheck >/dev/null 2>&1; then echo "-- govulncheck --"; find . -name "go.mod" -not -path "*/.git/*" -not -path "*/vendor/*" | xargs -I{} dirname {} | xargs -I{} sh -c 'cd {} && govulncheck ./... || true'; fi
-	@find . -name "package.json" -not -path "*/.git/*" -not -path "*/node_modules/*" -maxdepth 3 | xargs -I{} dirname {} | xargs -I{} sh -c 'cd {} && npm audit 2>/dev/null || true'
-	@if command -v gitleaks >/dev/null 2>&1; then echo "-- gitleaks --"; gitleaks detect --source . --no-git 2>/dev/null || true; fi
+	@bash scripts/security-scan.sh
 
 smoke-test:
 	@echo "Running smoke tests..."

--- a/docs/openwhisk_action_module/TROUBLESHOOTING.md
+++ b/docs/openwhisk_action_module/TROUBLESHOOTING.md
@@ -35,7 +35,7 @@ wsk property get --auth
 
 3. **Test API key**:
 ```bash
-curl -u namespace:key https://openwhisk.example.com/api/v1/namespaces
+curl -u YOUR_NAMESPACE:This15TotallyAnExampleKey! https://openwhisk.example.com/api/v1/namespaces
 ```
 
 #### Issue: "Cannot connect to OpenWhisk"
@@ -220,7 +220,7 @@ echo "1. Checking database..."
 psql $DATABASE_URL -c "SELECT 1" && echo "✓ Database OK"
 
 echo "2. Checking OpenWhisk..."
-curl -u namespace:key $OPENWHISK_API_HOST/api/v1/namespaces && echo "✓ OpenWhisk OK"
+curl -u YOUR_NAMESPACE:This15TotallyAnExampleKey! $OPENWHISK_API_HOST/api/v1/namespaces && echo "✓ OpenWhisk OK"
 
 echo "3. Checking REST API..."
 curl -s http://localhost:8082/health | jq '.status' && echo "✓ REST API OK"

--- a/docs/openwhisk_action_module/USAGE.md
+++ b/docs/openwhisk_action_module/USAGE.md
@@ -445,7 +445,7 @@ Solution:
 1. Verify `OPENWHISK_API_HOST` is correct
 2. Ensure OpenWhisk instance is running
 3. Check network connectivity: `curl -X GET $OPENWHISK_API_HOST/api/v1/namespaces`
-4. Verify API key: `curl -u namespace:key -X GET $OPENWHISK_API_HOST/api/v1/namespaces`
+4. Verify API key: `curl -u YOUR_NAMESPACE:This15TotallyAnExampleKey! -X GET $OPENWHISK_API_HOST/api/v1/namespaces`
 
 ### Invalid API Key
 

--- a/docs/shoutout_interaction_module/CONFIGURATION.md
+++ b/docs/shoutout_interaction_module/CONFIGURATION.md
@@ -23,7 +23,7 @@ Twitch application client ID for Helix API authentication.
 - **Type:** String
 - **Required:** Yes
 - **Where to get:** [Twitch Developer Console](https://dev.twitch.tv/console/apps)
-- **Example:** `TWITCH_CLIENT_ID=wlc4v5o2xjlpm0wdc5qx5oid4vb5ty`
+- **Example:** `TWITCH_CLIENT_ID=This15TotallyAnExampleClientId!`
 
 #### TWITCH_CLIENT_SECRET
 ```

--- a/docs/unified_music_module/CONFIGURATION.md
+++ b/docs/unified_music_module/CONFIGURATION.md
@@ -117,7 +117,7 @@ export SPOTIFY_REDIRECT_URI="http://localhost:8888/callback"
 
 **Example**:
 ```bash
-export YOUTUBE_API_KEY="AIzaSyD1234567890abcdefghijklmnopqrstuv"
+export YOUTUBE_API_KEY="This15TotallyAnExampleKey!NotReal"
 ```
 
 **API Limits**:

--- a/scripts/lib/checks.sh
+++ b/scripts/lib/checks.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Shared plumbing for the lint and security gates.
+#
+# Exists because the previous targets could not fail: every tool was wrapped in
+# `|| true`, and a tool that was not installed was skipped silently. A run with
+# nothing installed reported success having examined nothing.
+#
+# The distinction this file exists to make:
+#
+#   not applicable  no files of that kind in the repo    -> skip, harmless
+#   missing tool    files exist but the tool does not    -> FAILURE, they went unchecked
+#   ran and failed  the tool found something             -> FAILURE
+#
+# Conflating the first two is how a gate goes quietly dead. Bash 3.2 compatible
+# per general.md — no associative arrays, no mapfile.
+
+set -euo pipefail
+
+CHECKS_RAN=0
+CHECKS_PASSED=0
+CHECKS_FAILED=0
+CHECKS_SKIPPED=0
+CHECKS_MISSING=0
+CHECKS_FAILED_NAMES=""
+CHECKS_MISSING_NAMES=""
+
+# Paths every check must ignore. `.worktrees/` holds full checkouts of other
+# branches; scanning them reports another branch's problems against this one.
+CHECK_PRUNE_ARGS=(
+  -not -path "./.git/*"
+  -not -path "./.worktrees/*"
+  -not -path "*/node_modules/*"
+  -not -path "*/venv/*"
+  -not -path "*/.venv/*"
+  -not -path "*/vendor/*"
+  -not -path "*/__pycache__/*"
+)
+
+# discover <find-args...> — print matching paths, pruned. Never fails the script;
+# an empty result is a legitimate "not applicable".
+discover() {
+  find . "$@" "${CHECK_PRUNE_ARGS[@]}" 2>/dev/null || true
+}
+
+# count_lines <string> — number of non-empty lines.
+count_lines() {
+  [ -z "$1" ] && { echo 0; return; }
+  printf '%s\n' "$1" | grep -c . || true
+}
+
+# run_check <label> <tool> <file-count> <command...>
+#
+# file_count is the denominator: how many things this check is about to examine.
+# Zero means the check does not apply here and is skipped without penalty.
+run_check() {
+  local label="$1" tool="$2" count="$3"
+  shift 3
+
+  if [ "$count" -eq 0 ]; then
+    printf '  SKIP    %-16s no applicable files\n' "$label"
+    CHECKS_SKIPPED=$((CHECKS_SKIPPED + 1))
+    return 0
+  fi
+
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf '  MISSING %-16s %s not installed — %s file(s) went unchecked\n' \
+      "$label" "$tool" "$count"
+    CHECKS_MISSING=$((CHECKS_MISSING + 1))
+    CHECKS_MISSING_NAMES="$CHECKS_MISSING_NAMES $label"
+    return 0
+  fi
+
+  CHECKS_RAN=$((CHECKS_RAN + 1))
+  if "$@"; then
+    printf '  PASS    %-16s %s file(s)\n' "$label" "$count"
+    CHECKS_PASSED=$((CHECKS_PASSED + 1))
+  else
+    printf '  FAIL    %-16s %s file(s)\n' "$label" "$count"
+    CHECKS_FAILED=$((CHECKS_FAILED + 1))
+    CHECKS_FAILED_NAMES="$CHECKS_FAILED_NAMES $label"
+  fi
+}
+
+# --- Baselines -------------------------------------------------------------
+#
+# Turning these gates on revealed roughly 8,700 pre-existing findings, because
+# every tool had been wrapped in `|| true`. Two bad options and one good one:
+# block all work until the backlog is cleared, switch the gate back off, or
+# freeze the backlog at today's number and refuse to let it grow.
+#
+# The baseline is the third. A new finding fails the build; the counts only
+# ever move down. A check whose count has dropped says so, loudly, because a
+# baseline nobody lowers is just a higher `|| true`.
+
+CHECKS_BASELINE_FILE="${CHECKS_BASELINE_FILE:-.checks-baseline}"
+CHECKS_RATCHET_NOTES=""
+
+# baseline_for <key> — the allowed finding count, or 0 if unlisted.
+baseline_for() {
+  local key="$1" line
+  [ -f "$CHECKS_BASELINE_FILE" ] || { echo 0; return; }
+  line=$(grep -E "^${key}=" "$CHECKS_BASELINE_FILE" 2>/dev/null | tail -1 || true)
+  [ -z "$line" ] && { echo 0; return; }
+  echo "${line#*=}"
+}
+
+# run_counted_check <label> <tool> <file-count> <count-command...>
+#
+# The command prints the number of findings on stdout. Compared against the
+# baseline rather than against zero.
+run_counted_check() {
+  local label="$1" tool="$2" count="$3"
+  shift 3
+
+  if [ "$count" -eq 0 ]; then
+    printf '  SKIP    %-16s no applicable files\n' "$label"
+    CHECKS_SKIPPED=$((CHECKS_SKIPPED + 1))
+    return 0
+  fi
+
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf '  MISSING %-16s %s not installed — %s file(s) went unchecked\n' \
+      "$label" "$tool" "$count"
+    CHECKS_MISSING=$((CHECKS_MISSING + 1))
+    CHECKS_MISSING_NAMES="$CHECKS_MISSING_NAMES $label"
+    return 0
+  fi
+
+  local budget findings
+  budget=$(baseline_for "$label")
+  findings=$("$@" || true)
+  case "$findings" in ''|*[!0-9]*) findings=0 ;; esac
+
+  CHECKS_RAN=$((CHECKS_RAN + 1))
+  if [ "$findings" -gt "$budget" ]; then
+    printf '  FAIL    %-16s %s finding(s), baseline %s — %s new\n' \
+      "$label" "$findings" "$budget" "$((findings - budget))"
+    CHECKS_FAILED=$((CHECKS_FAILED + 1))
+    CHECKS_FAILED_NAMES="$CHECKS_FAILED_NAMES $label"
+  else
+    printf '  PASS    %-16s %s finding(s), baseline %s (%s file(s))\n' \
+      "$label" "$findings" "$budget" "$count"
+    CHECKS_PASSED=$((CHECKS_PASSED + 1))
+    if [ "$findings" -lt "$budget" ]; then
+      CHECKS_RATCHET_NOTES="$CHECKS_RATCHET_NOTES
+  $label: $budget -> $findings"
+    fi
+  fi
+}
+
+# finish_checks <suite-name>
+#
+# Reports the tally and decides the exit status. Prints counts always: "no
+# findings" without a denominator is indistinguishable from "nothing ran".
+finish_checks() {
+  local suite="$1"
+  local applicable=$((CHECKS_RAN + CHECKS_MISSING))
+
+  echo
+  echo "$suite: ${CHECKS_RAN} ran, ${CHECKS_PASSED} passed, ${CHECKS_FAILED} failed, ${CHECKS_MISSING} tool(s) missing, ${CHECKS_SKIPPED} not applicable"
+
+  if [ "$applicable" -eq 0 ]; then
+    echo "FAIL: no check applied to anything — the suite is misconfigured, not clean" >&2
+    return 1
+  fi
+
+  if [ "$CHECKS_FAILED" -gt 0 ]; then
+    echo "FAIL:$CHECKS_FAILED_NAMES" >&2
+    return 1
+  fi
+
+  if [ "$CHECKS_MISSING" -gt 0 ]; then
+    if [ "${ALLOW_MISSING_TOOLS:-0}" = "1" ]; then
+      echo "WARNING: tools missing, files unchecked:$CHECKS_MISSING_NAMES" >&2
+      echo "         (ALLOW_MISSING_TOOLS=1 — never set this in CI)" >&2
+      return 0
+    fi
+    echo "FAIL: tools missing, files unchecked:$CHECKS_MISSING_NAMES" >&2
+    echo "      install them, or set ALLOW_MISSING_TOOLS=1 for local runs" >&2
+    return 1
+  fi
+
+  if [ -n "$CHECKS_RATCHET_NOTES" ]; then
+    echo
+    echo "RATCHET — findings dropped; lower these in $CHECKS_BASELINE_FILE in this PR:$CHECKS_RATCHET_NOTES"
+  fi
+
+  return 0
+}

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Lint gate. Replaces a `make lint` in which every tool was wrapped in
+# `|| true`, so the target exited 0 no matter what any linter reported.
+#
+# Findings are counted against `.checks-baseline` rather than against zero:
+# switching these on revealed ~8,700 pre-existing findings, and a gate that
+# blocks every commit on day one gets switched back off by day two. New
+# findings fail; the baselines only move down.
+#
+# Usage: scripts/lint.sh                        (make lint)
+#        ALLOW_MISSING_TOOLS=1 scripts/lint.sh  (local, not all tools installed)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+# shellcheck source=scripts/lib/checks.sh
+. scripts/lib/checks.sh
+
+echo "=== Linting ==="
+
+py_files=$(discover -name "*.py")
+py_count=$(count_lines "$py_files")
+count_flake8() {
+  flake8 . --max-line-length=120 \
+    --exclude=.git,__pycache__,venv,.venv,node_modules,.worktrees,vendor \
+    2>/dev/null | grep -c . || true
+}
+run_counted_check "flake8" flake8 "$py_count" count_flake8
+
+sh_files=$(discover -name "*.sh")
+sh_count=$(count_lines "$sh_files")
+count_shellcheck() {
+  # shellcheck disable=SC2086
+  shellcheck -f gcc $sh_files 2>/dev/null | grep -c . || true
+}
+run_counted_check "shellcheck" shellcheck "$sh_count" count_shellcheck
+
+docker_files=$(discover -name "Dockerfile*")
+docker_count=$(count_lines "$docker_files")
+count_hadolint() {
+  # shellcheck disable=SC2086
+  hadolint -f tty $docker_files 2>/dev/null | grep -c . || true
+}
+run_counted_check "hadolint" hadolint "$docker_count" count_hadolint
+
+# Go is being phased out (critical-rules.md). This skips cleanly once the last
+# go.mod is gone, rather than needing the check deleted.
+go_mods=$(discover -name "go.mod")
+go_count=$(count_lines "$go_mods")
+count_golangci() {
+  local total=0 dir n
+  for mod in $go_mods; do
+    dir=$(dirname "$mod")
+    n=$( ( cd "$dir" && golangci-lint run 2>/dev/null ) | grep -c . || true )
+    total=$((total + n))
+  done
+  echo "$total"
+}
+run_counted_check "golangci-lint" golangci-lint "$go_count" count_golangci
+
+# Workflow security. HIGH only — the medium backlog is large and mostly
+# advisory, and gating on it now would bury the findings that matter.
+wf_count=$(count_lines "$(discover -path "./.github/workflows/*" -name "*.yml")")
+count_zizmor() {
+  zizmor .github/workflows/ --min-severity high 2>/dev/null \
+    | grep -cE "^(error|warning)\[" || true
+}
+run_counted_check "zizmor" zizmor "$wf_count" count_zizmor
+
+finish_checks "lint"

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Security gate. Replaces a `make test-security` in which every scanner was
+# wrapped in `|| true` and several had stderr sent to /dev/null, so a scanner
+# that crashed looked exactly like one that found nothing.
+#
+# Usage: scripts/security-scan.sh
+#        ALLOW_MISSING_TOOLS=1 scripts/security-scan.sh   (local)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+# shellcheck source=scripts/lib/checks.sh
+. scripts/lib/checks.sh
+
+echo "=== Security Scans ==="
+
+py_files=$(discover -name "*.py")
+py_count=$(count_lines "$py_files")
+# pip-audit must run on the same Python major the images use. Lockfiles are
+# resolved per version, so auditing a 3.13 lockfile on 3.12 reports phantom
+# missing dependencies for markers like `python_version < "3.13"` — 15 of 29
+# lockfiles "failed" that way before this was pinned. uv gives a 3.13
+# interpreter without requiring one on PATH.
+PY_AUDIT_313=0
+if command -v uv >/dev/null 2>&1; then
+  PY_AUDIT_313=1
+fi
+
+run_bandit() {
+  # HIGH severity + HIGH confidence only. The MEDIUM backlog is real but
+  # pre-existing; gating on it now would mean the gate is switched off again
+  # within a week. Ratchet down deliberately, never up.
+  bandit -r . -lll -iii --quiet \
+    --exclude ./node_modules,./.worktrees,./tests,./.venv,./venv,./mobile,./.git
+}
+run_check "bandit" bandit "$py_count" run_bandit
+
+# Only hash-pinned lockfiles gate. Unhashed requirement files carry known
+# pre-existing CVEs and are reported by the CI job, not by this local gate.
+# `&& echo` would leave the loop's status non-zero when the final file has no
+# hashes, and `set -e` would abort the whole suite on a legitimately empty
+# result. Discovery finding nothing is not a failure; a gate finding nothing is.
+locks=$(discover -name "requirements.txt" | while read -r f; do
+  if grep -q -- "--hash=sha256" "$f" 2>/dev/null; then echo "$f"; fi
+done)
+lock_count=$(count_lines "$locks")
+count_vulnerable_locks() {
+  local bad=0
+  for f in $locks; do
+    # PYSEC-2022-252: deep-translator PyPI account takeover, no fixed version
+    # published, so every release since 1.8.5 is flagged in perpetuity.
+    if [ "$PY_AUDIT_313" = "1" ]; then
+      uv run --quiet --python 3.13 --with pip-audit pip-audit -r "$f" \
+        --no-deps --progress-spinner off --ignore-vuln PYSEC-2022-252 \
+        >/dev/null 2>&1 || { echo "  vulnerable: $f" >&2; bad=$((bad + 1)); }
+    else
+      pip-audit -r "$f" --no-deps --progress-spinner off \
+        --ignore-vuln PYSEC-2022-252 >/dev/null 2>&1 \
+        || { echo "  vulnerable: $f" >&2; bad=$((bad + 1)); }
+    fi
+  done
+  echo "$bad"
+}
+if [ "$PY_AUDIT_313" = "1" ]; then
+  run_counted_check "pip-audit" uv "$lock_count" count_vulnerable_locks
+else
+  run_counted_check "pip-audit" pip-audit "$lock_count" count_vulnerable_locks
+fi
+
+pkg_files=$(discover -name "package-lock.json")
+pkg_count=$(count_lines "$pkg_files")
+repo_root=$(pwd)
+count_vulnerable_npm() {
+  local bad=0 dir
+  for f in $pkg_files; do
+    dir=$(dirname "$f")
+    ( cd "$dir" && NPM_AUDIT_ALLOW="${NPM_AUDIT_ALLOW:-}" \
+        node "$repo_root/.github/scripts/npm-audit.mjs" >/dev/null 2>&1 ) \
+      || { echo "  vulnerable: $dir" >&2; bad=$((bad + 1)); }
+  done
+  echo "$bad"
+}
+run_counted_check "npm-audit" node "$pkg_count" count_vulnerable_npm
+
+go_mods=$(discover -name "go.mod")
+go_count=$(count_lines "$go_mods")
+# core/module_rtc is the only Go left (822 lines) and is slated for a Rust
+# rewrite at P3. These checks skip themselves once the last go.mod is gone.
+count_gosec() {
+  local total=0 dir n
+  for mod in $go_mods; do
+    dir=$(dirname "$mod")
+    n=$( ( cd "$dir" && gosec -quiet ./... 2>&1 ) | grep -cE "^\\[/" || true )
+    total=$((total + n))
+  done
+  echo "$total"
+}
+run_counted_check "gosec" gosec "$go_count" count_gosec
+
+count_govulncheck() {
+  local total=0 dir n
+  for mod in $go_mods; do
+    dir=$(dirname "$mod")
+    n=$( ( cd "$dir" && govulncheck ./... 2>&1 ) | grep -cE "^Vulnerability #" || true )
+    total=$((total + n))
+  done
+  echo "$total"
+}
+run_counted_check "govulncheck" govulncheck "$go_count" count_govulncheck
+
+# Secrets: scan tracked files only. `--no-git --source .` walks the working
+# tree including .worktrees/, which reports other branches' findings here.
+tracked=$(git ls-files | wc -l | tr -d ' ')
+count_gitleaks() {
+  gitleaks detect --source . --redact --no-banner --report-format json \
+    --report-path /dev/stdout 2>/dev/null \
+    | grep -c '"RuleID"' || true
+}
+run_counted_check "gitleaks" gitleaks "$tracked" count_gitleaks
+
+finish_checks "security"


### PR DESCRIPTION
First task on the v3 line, ahead of P0 proper: both targets exited 0 unconditionally, so ~8,700 findings had accumulated behind a permanently green gate.

`|| true` was the visible defect; three more were equally silent — a missing tool skipped its check (zero examined = pass), nothing pruned `.worktrees/` so the targets scanned six other branches, and `2>/dev/null` made a crashed scanner look clean.

Findings are now counted against `.checks-baseline` rather than zero: new findings fail, existing ones do not, and a run under baseline prints a RATCHET line naming the number to lower. Blocking every commit on day one is how a gate gets switched off again by day two.

**Verified by making each failure mode happen on purpose:**

| Probe | Result |
|---|---|
| New flake8 finding | FAIL — 2257 vs baseline 2250, 7 new |
| Probe removed | PASS |
| Suite examining nothing | FAIL — "misconfigured, not clean" |
| Tool missing, files applicable | FAIL — "42 file(s) went unchecked" |
| Same, `ALLOW_MISSING_TOOLS=1` | PASS with warning |

Also fixes a defect in this change rather than the old code: bare `pip-audit` runs on whatever `python3` PATH gives (3.12 here), and lockfiles resolve per Python version — so `python_version < "3.13"` markers made 15 of 29 hash-pinned lockfiles look vulnerable while CI reported none. Pinned to 3.13 via uv; local now agrees with CI at 0/29.

Second commit makes four documentation credential examples unmistakably fake, dropping working-tree high-signal gitleaks findings from 5 to 1. The remaining one is a dev DB password in a migration that provisions that user — functional code, deliberately untouched.