### PR TITLE
chore(v3): migrate Redis to Valkey + assemble missing REDIS_URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
     restart: unless-stopped
 
   infra-redis:
-    image: redis:7-bookworm@sha256:a5995dfdf108997f8a7c9587f54fad5e94ed5848de5236a6b28119e99efd67e0
+    image: valkey/valkey:8-bookworm@sha256:fea8b3e67b15729d4bb70589eb03367bab9ad1ee89c876f54327fc7c6e618571
     container_name: infra-redis
     entrypoint: ["/usr/local/bin/docker-entrypoint.sh"]
     environment:

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -19,9 +19,18 @@ The model is Nextcloud's: a core platform plus an app store, where the shipped d
 are themselves apps. Nothing is a privileged built-in, because a built-in that cannot be
 replaced makes the extension point decorative.
 
-v3.0.0 ships **feature parity with v2.2.x** — Social and Bot fully populated — plus
-lightweight Customer and Marketing. It does not attempt a complete CRM or a full
-conferencing suite; those are 3.x work with their own specs.
+**v3.0.0 ships all four modules' full feature set in one release** — Social, Customer, Bot
+and Marketing, not staged across 3.x minors. This supersedes the earlier "parity plus
+lightweight Customer/Marketing" scope.
+
+One honest caveat on that ambition, stated so it is a known risk rather than a surprise:
+Customer is a SuiteCRM/Odoo-class CRM and Social's conferencing is a Zoom/Teams replacement —
+each is a large product in its own right, and "full feature set in one release" is a
+multi-quarter undertaking, not a single milestone. The architecture here (Core → Modules →
+Features → Apps) is what makes shipping them together *tractable* — every feature is an App
+behind a Feature contract, so the modules grow independently and in parallel — but the
+calendar cost is real. Phases P2–P5 still exist as the build order; what changes is that they
+all land in v3.0.0 rather than seeding a lightweight cut and deferring the rest.
 
 ## Reuse is the default; rewriting needs a reason
 
@@ -932,8 +941,8 @@ its source; rows sourced from "this design" are proposals, not standards.
 | All four Modules, core functionality | Free | `critical-rules.md` — "Core product, no license-gated functionality" |
 | Bot: platform connectors, commands, interactions | Free | ungated in v2.2.x |
 | Social: chat, presence, communities | Free | ungated in v2.2.x |
-| Customer: accounts, contacts, opportunities | Free | lightweight by v3.0.0 scope |
-| Marketing: manual posting | Free | lightweight by v3.0.0 scope |
+| Customer: full CRM — accounts, contacts, opportunities, pipelines, cases | Free | core CRM in v3.0.0 |
+| Marketing: full scheduling + publishing + cross-platform analytics | mixed | see Marketing tiering |
 | More than one admin | Professional | `critical-rules.md` — Free is capped at 1 admin |
 | **More than one tenant** | **Enterprise** | Free and Professional are both capped at the single default tenant; matches WaddleAI, where multi-tenancy is Enterprise |
 | Whitelabelling | Professional | `critical-rules.md` |
@@ -1168,8 +1177,8 @@ Detail lives in the companion plan. Summary:
 | P1 | App manifest, registry, binding resolution; rename to `app_installations`; convert 2–3 Bot units as proof | A community can rebind a Feature to a non-default App |
 | P2 | Bot — all triggers/actions/interactions become Apps | v2.2.x Bot parity, all as Apps |
 | P3 | Social — community, presence, RTC, browser-source as Apps | v2.2.x Social parity |
-| P4 | Customer + Marketing lightweight Apps | accounts/contacts/opportunities; scheduling + analytics |
-| P5 | Cut v3.0.0 | parity verified against v2.2.x |
+| P4 | Customer + Marketing full Apps | complete CRM (accounts→cases); scheduling, publishing, analytics |
+| P5 | Cut v3.0.0 | all four modules' full feature set verified; parity vs v2.2.x plus new modules |
 
 ## Risks
 

--- a/k8s/helm/waddlebot/templates/secrets.yaml
+++ b/k8s/helm/waddlebot/templates/secrets.yaml
@@ -17,6 +17,13 @@ stringData:
   DATABASE_URL: "postgresql://{{ .Values.infrastructure.postgresql.username }}:{{ .Values.infrastructure.postgresql.password | default "REPLACE_ME" }}@{{ .Values.infrastructure.postgresql.service.name }}:{{ .Values.infrastructure.postgresql.service.port }}/{{ .Values.infrastructure.postgresql.database }}"
   # Redis Credentials (admin password)
   REDIS_PASSWORD: {{ .Values.infrastructure.redis.password | default "REPLACE_ME" | quote }}
+  # Assembled connection URL, mirroring DATABASE_URL above. The configmap
+  # provides REDIS_HOST/PORT as components, but 44 modules read REDIS_URL and
+  # would otherwise fall back to their localhost default — under the Helm-only
+  # deploy path that meant Redis/Valkey was unreachable for those modules.
+  # Password-only auth uses an empty username (redis://:pass@host). DB index 0
+  # matches every module's REDIS_DB default.
+  REDIS_URL: "redis://:{{ .Values.infrastructure.redis.password | default "REPLACE_ME" }}@{{ .Values.infrastructure.redis.service.name }}:{{ .Values.infrastructure.redis.service.port }}/0"
   REDIS_ADMIN_PASSWORD: {{ .Values.infrastructure.redis.modulePasswords.admin | default "REPLACE_ME" | quote }}
   # Module-specific Redis passwords (matches docker-compose.yml ACL setup)
   REDIS_ROUTER_PASSWORD: {{ .Values.infrastructure.redis.modulePasswords.router | default "REPLACE_ME" | quote }}

--- a/k8s/helm/waddlebot/values-beta.yaml
+++ b/k8s/helm/waddlebot/values-beta.yaml
@@ -21,7 +21,7 @@ infrastructure:
       storageClass: "longhorn"
   redis:
     enabled: true
-    image: redis:7-bookworm@sha256:33d7c9a245edd95e6703a0addbeaa48fe40c3b3b4783627a72085155462ebfdb
+    image: valkey/valkey:8-bookworm@sha256:fea8b3e67b15729d4bb70589eb03367bab9ad1ee89c876f54327fc7c6e618571
     persistence:
       size: 2Gi
       storageClass: "longhorn"

--- a/k8s/helm/waddlebot/values.yaml
+++ b/k8s/helm/waddlebot/values.yaml
@@ -100,7 +100,7 @@ infrastructure:
   # Redis Cache & Sessions
   redis:
     enabled: true
-    image: redis:7-bookworm@sha256:33d7c9a245edd95e6703a0addbeaa48fe40c3b3b4783627a72085155462ebfdb  # Use Debian instead of Alpine for compatibility
+    image: valkey/valkey:8-bookworm@sha256:fea8b3e67b15729d4bb70589eb03367bab9ad1ee89c876f54327fc7c6e618571  # Valkey (Redis-compatible fork); Debian bookworm, digest-pinned
     port: 6379
     password: "REPLACE_ME"  # Only used for secrets, actual Redis already running
     # Module-specific Redis passwords (matches docker-compose.yml ACL setup)

--- a/k8s/infrastructure.yaml
+++ b/k8s/infrastructure.yaml
@@ -118,7 +118,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:7-bookworm@sha256:33d7c9a245edd95e6703a0addbeaa48fe40c3b3b4783627a72085155462ebfdb
+          image: valkey/valkey:8-bookworm@sha256:fea8b3e67b15729d4bb70589eb03367bab9ad1ee89c876f54327fc7c6e618571
           command:
             - redis-server
             - --requirepass

--- a/k8s/kustomize/components/infrastructure/redis.yaml
+++ b/k8s/kustomize/components/infrastructure/redis.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:7-bookworm@sha256:33d7c9a245edd95e6703a0addbeaa48fe40c3b3b4783627a72085155462ebfdb
+        image: valkey/valkey:8-bookworm@sha256:fea8b3e67b15729d4bb70589eb03367bab9ad1ee89c876f54327fc7c6e618571
         imagePullPolicy: IfNotPresent
         command:
         - redis-server


### PR DESCRIPTION
Two directives from this session: **use Valkey instead of Redis**, and **ship all features in one v3.0.0 release**.

## Redis → Valkey (drop-in, verified)

All 5 literal `redis:7-bookworm` image references → `valkey/valkey:8-bookworm@sha256:fea8b3e6…` (digest-pinned); the helm redis template is values-driven so it follows.

Valkey speaks the Redis wire protocol and ships `redis-server`→`valkey-server` / `redis-cli`→`valkey-cli` compat symlinks, so the `command: [redis-server]` overrides and `redis-cli` health probes work unchanged. **Verified** by booting the image with the exact production args (`--requirepass`/`--appendonly`/`--maxmemory`/`--maxmemory-policy`) → `redis-cli` auth returns PONG.

Client side is untouched — service `infra-redis`, env `REDIS_*`, all client libraries stay (renaming would break 44 modules for zero gain).

## REDIS_URL fix (the latent bug from Task 0.1)

Task 0.1's diff analysis surfaced this: Helm provides Redis as **components** (`REDIS_HOST`/`PORT`/`DB` + per-service `*_PASSWORD` ACLs) but never assembled a `REDIS_URL` — yet **44 canonical modules read `REDIS_URL`** (defaulting to localhost) and only 6 read `REDIS_HOST`. Under the Helm-only path, Valkey was unreachable for those 44.

The secret now assembles `REDIS_URL` from the shared password + host/port, DB 0, mirroring `DATABASE_URL`. `helm template` → 64 objects, `helm lint` clean, resolves to `redis://:***@infra-redis:6379/0`.

## Scope

Design doc updated: **v3.0.0 ships all four modules' full feature set in one release**, superseding the earlier "parity + lightweight Customer/Marketing." Honest caveat recorded — full CRM + conferencing is multi-quarter; the architecture makes parallel delivery tractable but the calendar cost is real.

## Files
7 changed: 5 image swaps, 1 secret (`REDIS_URL`), 1 design doc.
