### PR TITLE
chore(v3 P0.6): documentation reference gate

### DIFF
--- a/.checks-baseline
+++ b/.checks-baseline
@@ -35,3 +35,7 @@ govulncheck=2
 # Per devops.md the pre-commit hook should use `gitleaks protect --staged`,
 # which checks what you are about to commit rather than all of history.
 gitleaks=420
+
+# Documentation reference gate (scripts/check-doc-refs.sh). Dead repo paths
+# referenced in docs/**/*.md. Seeded 2026-08-29; lower as docs are corrected.
+doc-refs=27

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: dev test test-unit test-integration test-e2e test-functional test-security \
         smoke-test lint build docker-build docker-push deploy-dev deploy-prod \
-        seed-mock-data clean pre-commit run-ai-local
+        seed-mock-data clean pre-commit run-ai-local check-docs
 
 dev:
 	docker-compose up
@@ -15,6 +15,9 @@ docker-push:
 
 lint:
 	@bash scripts/lint.sh
+
+check-docs:
+	@bash scripts/check-doc-refs.sh
 
 test:
 	@$(MAKE) test-unit

--- a/scripts/check-doc-refs.sh
+++ b/scripts/check-doc-refs.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Documentation reference gate. Extracts every repository path referenced in
+# backticks in docs/**/*.md and asserts each one still exists on disk.
+#
+# Docs go stale because nothing fails when they do. This is the failing thing:
+# a `services/foo` in a doc that no longer exists on disk is a dead reference,
+# and the count of dead references may not exceed DOC_REF_BUDGET.
+#
+# The budget is seeded at today's measured debt and ratcheted down, never up —
+# existing debt stays visible without blocking work, and any NEW dead reference
+# fails immediately.
+#
+# A run that extracts zero references is itself a FAILURE: a validator pointed
+# at a moved directory finds nothing and reports clean. The denominator is part
+# of the result, so it is guarded and printed.
+#
+# Bash 3.2 compatible (general.md) — no associative arrays, no mapfile.
+#
+# Usage: scripts/check-doc-refs.sh            full gate (make check-docs)
+#        scripts/check-doc-refs.sh --count    print only the dead count (lint)
+#        DOC_REF_BUDGET=N scripts/check-doc-refs.sh   override the budget
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Seeded 2026-08-29 by measuring the tree at HEAD. Lower as phases land; never
+# raise it.
+DOC_REF_BUDGET="${DOC_REF_BUDGET:-27}"
+
+count_only=0
+[ "${1:-}" = "--count" ] && count_only=1
+
+# Every repo path referenced in backticks under a top-level dir we own. Trailing
+# slashes normalised off; deduplicated. `.worktrees/` holds other branches'
+# checkouts and is excluded so this branch is never judged against their docs.
+# The regex is a literal grep pattern; single quotes are intentional.
+# shellcheck disable=SC2016
+refs=$(grep -rhoE '`(action|core|trigger|processing|services|libs|admin|k8s)/[a-zA-Z0-9_/-]+`' \
+        docs/ --include='*.md' --exclude-dir='.worktrees' \
+        | tr -d '`' | sed 's:/$::' | sort -u)
+total=$(printf '%s\n' "$refs" | grep -c . || true)
+
+if [ "$total" -eq 0 ]; then
+  echo "FAIL: zero references extracted — validator is broken (moved docs/ or bad regex)" >&2
+  exit 1
+fi
+
+dead=0
+dead_list=""
+for r in $refs; do
+  if [ ! -e "$r" ]; then
+    dead=$((dead + 1))
+    dead_list="${dead_list}dead: ${r}"$'\n'
+  fi
+done
+
+if [ "$count_only" -eq 1 ]; then
+  echo "$dead"
+  exit 0
+fi
+
+[ -n "$dead_list" ] && printf '%s' "$dead_list"
+echo "examined=$total dead=$dead allowed=$DOC_REF_BUDGET"
+[ "$dead" -le "$DOC_REF_BUDGET" ]

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -66,4 +66,15 @@ count_zizmor() {
 }
 run_counted_check "zizmor" zizmor "$wf_count" count_zizmor
 
+# Documentation reference gate. Counts repo paths referenced in docs/**/*.md
+# that no longer exist on disk, ratcheted against the baseline. The script owns
+# the zero-references guard; here a broken run is forced over budget so lint
+# fails rather than silently passing.
+doc_md_files=$(discover -path "./docs/*" -name "*.md")
+doc_md_count=$(count_lines "$doc_md_files")
+count_doc_refs() {
+  scripts/check-doc-refs.sh --count 2>/dev/null || echo 999999
+}
+run_counted_check "doc-refs" bash "$doc_md_count" count_doc_refs
+
 finish_checks "lint"


### PR DESCRIPTION
Task 0.6. `scripts/check-doc-refs.sh` asserts every backticked repo path in docs exists, fails when dead count exceeds `DOC_REF_BUDGET` (baseline 27, the measured debt), ratchets down. Wired into `make lint` as a counted check + `make check-docs`. Zero-refs = failure (validator broken). Verified: real exit 1 on a new dead ref, 0 at baseline.