### PR TITLE
docs(v3 P0.2): Core boundary inventory + three-pillar framing + Task 1.5 licensing

### DIFF
--- a/docs/architecture/core-boundary.md
+++ b/docs/architecture/core-boundary.md
@@ -1,0 +1,78 @@
+# Core Boundary Inventory (v3.0.x Task 0.2)
+
+The rule applied to every service: **does more than one Module need it? → Core. Exactly
+one Module → owned by that Module.** Modules are Bot, Social, Customer, Marketing. Core is
+the mandatory platform every Module depends on.
+
+Each row cites a *real consumer* as evidence — a gRPC stub import, an `*_API_URL` client
+call, a `docker-compose` env wiring, or a design-doc seed. A service is Core only where two
+or more Modules can be named; a single consumer makes it Module-owned, regardless of its
+name (`*_core_module` naming is not evidence).
+
+## Core (needed by ≥2 Modules)
+
+| Service | Source | Evidence |
+|---------|--------|----------|
+| identity | `core/identity_core_module` | OIDC/JWT/tenant claim — every service authenticates against it |
+| security | `core/security_core_module` | authz enforcement + audit — every Module's permission checks depend on it |
+| credentials | `core/credential_manager_module` | per-tenant secret custody — all platform integrations need it |
+| tenancy | `core/community_module` | communities/membership — every Module scopes queries to `community_id` |
+| reputation | `core/reputation_module` | Bot (router, loyalty) **and** Core security (bad-actor) + analytics (user-stats) |
+| analytics | `core/analytics_core_module` | shared telemetry sink — all Modules emit; Marketing reads it |
+| workflow | `core/workflow_core_module` | cross-Module automation executor — orchestrates every Module over gRPC |
+| event bus | **library** split from `processing/router_module` | consolidated `flask_core.StreamPipeline`; all stages publish/consume (see router split) |
+| marketplace | `admin/marketplace_module` | catalog / subscriptions / App installs — load-bearing for every Module |
+| hub | `admin/hub_module` | admin shell that mounts enabled Modules |
+| entitlement | new entitlement client — Task 1.5, not yet built | tier × flag gate consulted by every Feature in every Module |
+
+## Module-owned (exactly one Module)
+
+### Bot
+
+All platform plumbing — receivers, actions, interaction commands, and the router's command half.
+
+- **Triggers** `trigger/receiver/*` (8): discord, googlechat, kick_flask, mattermost, slack, teams, twitch, youtube_live (+ `platform_base` shim)
+- **Actions** `action/pushing/*` (10): discord, gcp_functions, googlechat, lambda, mattermost, openwhisk, slack, teams, twitch, youtube
+- **Interactions** `action/interactive/*` (Bot subset): ai, clip, server_manager, server_status *(deprecated)*
+- **From `core/`**: `ai_researcher_module` (standalone AI assistant), `labels_core_module` (only `calendar_interaction` consumes it — fails the 2-Module test despite the `_core_` name), `unified_music_module` (song-request provider library, dormant)
+- **Router command half** (`processing/router_module`): `command_processor.py`, `command_registry.py`, `emote_service.py`, `emote_providers/*`, `context_service.py`, `grpc_clients.py`, `controllers/router.py`, `controllers/admin.py`
+
+### Social
+
+Community-facing social features, chat, presence, conferencing, and stream surfaces.
+
+- **From `core/`**: `browser_source_core_module` (OBS overlay surface), `module_rtc` (Go WebRTC/SFU conferencing — the Rust-rewrite target), `video_proxy_module` (RTMP simulcast)
+- **Interactions** `action/interactive/*` (Social subset): presence, shoutout, alias, quote, loyalty, inventory, calendar, lfg, memories, spotify, youtube_music, translate
+
+### Marketing
+
+- **From `core/`**: `engagement_module` (forms/polls — only hub consumes; design seeds Marketing)
+
+### Customer
+
+Green-field — nothing exists yet. Built new in P4.
+
+## Flagged judgment calls (record, don't bury)
+
+These were decided on the balance of evidence but are worth revisiting if a second consumer appears:
+
+| Item | Decided | If wrong |
+|------|---------|----------|
+| The 8 community-facing interactions (loyalty, inventory, calendar, lfg, memories, spotify, youtube_music, translate) | **Social** — community engagement, not platform plumbing | apply the literal "interaction = Bot" default → they flip to Bot |
+| `translate` | Social | strongest **Core** candidate — it has a gRPC handler and cross-cuts; promote to Core (Bot + Social) if platform receivers call it to translate inbound chat |
+| `labels_core_module` | **Bot** (single consumer) | promote to Core if a Social/Marketing runtime consumer is added |
+| `reputation_module` | **Core** | its Social consumer is indirect (via security/analytics), not a direct Social call — still ≥2 Modules, so Core holds |
+| `ai_researcher` / `ai` | Bot | either could be Social (community chatbot) or Core (WaddleAI reused) — Bot as the bot's own engine |
+
+## Consequences for later phases
+
+- **Router split (0.3b):** the file-level Core/Bot division above is the input — event-bus/generic-infra files (`cache_manager`, `session_manager`, `rate_limiter`, the `StreamPipeline` wiring) to Core; the command files to Bot.
+- **Seven containers (0.5):** Core services land in `svc-core`; Bot/Social/Marketing/Customer code loads into `svc-ingest`/`svc-process`/`svc-action` by pipeline stage, `svc-rtc` for `module_rtc`.
+- **Caveat:** `community_module` and `analytics_core_module` are deliberately dual-natured (Core tenancy/telemetry *and* a Social/Marketing consumer surface). They are Core, but their Module-facing APIs are Feature contracts, not internal calls.
+
+## Note on `services/`
+
+The `services/*` aggregators were extraction sources for the seven-container consolidation, not
+surviving containers — their 21 dead module subdirs were already deleted in Task 0.1, and the
+aggregators themselves are removed at P5. This inventory classifies the *canonical* trees, which
+is what survives.

--- a/docs/plans/2026-08-26-v3-scbm-apps-design.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps-design.md
@@ -19,6 +19,28 @@ The model is Nextcloud's: a core platform plus an app store, where the shipped d
 are themselves apps. Nothing is a privileged built-in, because a built-in that cannot be
 replaced makes the extension point decorative.
 
+## Why a major version — the three pillars
+
+v3.0.0 exists for three reasons, and every part of this design serves one of them:
+
+1. **Proper feature flags.** Every feature behind a PostHog flag, defaulted OFF, resolved
+   per tenant — replacing the current state where PostHog is **not wired at all**.
+2. **Proper licensing.** A single entitlement path built on the published `penguin-licensing`
+   package, tier × flag, replacing today's hand-rolled per-module `license_service.py` copies
+   (the published lib is used nowhere yet, and the `PREMIUM_*` scheme covers only 2 of ~40
+   modules).
+3. **Modularity.** Core → Module → Feature → App, so the product is composed and swappable
+   rather than a flat mesh of ~40 co-equal services.
+
+These are not three separate workstreams — they are one mechanism. A **Feature** is the unit
+of all three at once: it is a flag (pillar 1), it is licensed by tier (pillar 2), and it is
+the contract an **App** implements inside a **Module** (pillar 3). Get the Feature abstraction
+right and the three pillars fall out of it; get it wrong and none of them hold.
+
+**Consequence for sequencing:** the entitlement client (plan Task 1.5) and the Feature/flag
+seeding (Task 1.4) are load-bearing for the whole release, not late polish. They gate every
+App. Treat them with the same weight as the P0 foundations, not as P1 cleanup.
+
 **v3.0.0 ships all four modules' full feature set in one release** — Social, Customer, Bot
 and Marketing, not staged across 3.x minors. This supersedes the earlier "parity plus
 lightweight Customer/Marketing" scope.

--- a/docs/plans/2026-08-26-v3-scbm-apps.md
+++ b/docs/plans/2026-08-26-v3-scbm-apps.md
@@ -655,15 +655,24 @@ Note the WaddleAI seed's docstring warning: `seed_db.py`/`seed_test_data.py` are
 
 **Files:**
 - Create: `libs/entitlement/`
+- Delete: `core/video_proxy_module/services/license_service.py`, `core/workflow_core_module/services/license_service.py`
+- Migrate: every caller of those, and the `PREMIUM_*` scheme (`PREMIUM_FEATURES`, `PREMIUM_LIMITS`, `PREMIUM_BYPASS_DOMAINS` — ~83 `premium` references)
 
-Two gates, both must pass: license tier entitles the Feature **and** its PostHog flag evaluates true for the tenant.
+**Current state this replaces (verified):** licensing is hand-rolled today — two copied `license_service.py` files hit `license.penguintech.io` with their own client code, the published `penguin-licensing` PyPI package is used **nowhere**, and **PostHog is not wired at all**. So the two-layer gate is currently just the tier half, hand-rolled, in 2 of ~40 modules. This task makes it proper.
+
+**Wrap the published packages, do not re-hand-roll.** Per `backend.md` Shared Libraries — "NEVER copy utility code into local `shared/` folders; use published packages" — the entitlement client composes:
+- `penguin-licensing` (PyPI) for tier/entitlement against `license.penguintech.io`
+- `posthog` SDK for flag evaluation against the self-hosted CE
+The two hand-rolled `license_service.py` copies are exactly the anti-pattern that rule forbids; deleting them is part of this task, not a follow-up.
+
+Two gates, both must pass: license tier entitles the Feature **and** its PostHog flag evaluates true for the tenant. `PREMIUM_*` capabilities migrate onto Feature flags (`waddles.<module>.<feature>`) with their tier from Task 1.1's mapping.
 
 Degradation rules, which are the part that gets this wrong in production:
 - either service unreachable → last-known cached value
 - a flag never seen before → OFF, never open
 - never crash a request path on an entitlement lookup
 
-**Test:** simulate both services down with a warm cache, and with a cold cache. Cold cache plus unknown flag must resolve OFF.
+**Test:** simulate both services down with a warm cache, and with a cold cache. Cold cache plus unknown flag must resolve OFF. Assert no `license_service.py` and no `PREMIUM_BYPASS_DOMAINS` remain (`grep` gate), so the hand-rolled path cannot survive alongside the new one.
 
 ### Task 1.6: Convert three Bot units as proof
 


### PR DESCRIPTION
**Task 0.2** — classifies every canonical service Core-vs-Module by the rule *needed by ≥2 Modules → Core*, each row citing a real consumer. Produced by 3 parallel analysis agents; two design-doc hints overridden on evidence (`labels`→Bot, `reputation`→Core-via-security/analytics).

Also folds in two user-prompted framing changes:
- **Three pillars** stated at the top of the design: proper feature flags, proper licensing, modularity — one mechanism (the Feature), not three workstreams.
- **Task 1.5 strengthened**: mandates wrapping the *published* `penguin-licensing` + `posthog` packages, deleting the 2 hand-rolled `license_service.py` copies, and migrating the `PREMIUM_*` scheme — after verifying licensing is hand-rolled today with PostHog not wired at all.

Docs-only.