### PR TITLE
chore(v3 P0.3b): keep the event-bus library free of platform vocabulary

### DIFF
--- a/libs/flask_core/flask_core/message_queue.py
+++ b/libs/flask_core/flask_core/message_queue.py
@@ -142,7 +142,7 @@ class MessageQueue:
         Publish message to stream.
 
         Args:
-            stream: Stream name (e.g., 'events', 'commands')
+            stream: Stream name (e.g., 'events', 'process')
             message: Message data (must be JSON-serializable)
             max_len: Maximum stream length (oldest messages trimmed)
 

--- a/libs/flask_core/flask_core/stream_pipeline.py
+++ b/libs/flask_core/flask_core/stream_pipeline.py
@@ -2,7 +2,7 @@
 Redis Streams Pipeline for Event-Driven Architecture
 
 Provides a high-level event streaming pipeline with:
-- Multiple event streams (inbound, commands, actions, responses)
+- Multiple event streams (inbound, process, actions, responses)
 - Dead letter queue support
 - Consumer group management
 - Event acknowledgment and retry logic
@@ -47,7 +47,7 @@ class StreamPipeline:
 
     Manages multiple event streams with dedicated purposes:
     - inbound: External events entering the system
-    - commands: User commands to be executed
+    - process: Business logic processing of inbound events
     - actions: System actions to be performed
     - responses: Responses to be sent back
 
@@ -62,7 +62,7 @@ class StreamPipeline:
 
     # Default stream names
     STREAM_INBOUND = "events:inbound"
-    STREAM_COMMANDS = "events:commands"
+    STREAM_PROCESS = "events:process"
     STREAM_ACTIONS = "events:actions"
     STREAM_RESPONSES = "events:responses"
 
@@ -182,7 +182,7 @@ class StreamPipeline:
         Publish event to a stream.
 
         Args:
-            stream_name: Stream name (e.g., 'events:inbound', 'events:commands')
+            stream_name: Stream name (e.g., 'events:inbound', 'events:process')
             event_data: Event data (must be JSON-serializable)
             max_len: Maximum stream length (oldest events trimmed)
 
@@ -191,8 +191,8 @@ class StreamPipeline:
 
         Example:
             message_id = await pipeline.publish_event(
-                'events:commands',
-                {'command': 'translate', 'text': 'Hello'}
+                'events:process',
+                {'type': 'translate', 'text': 'Hello'}
             )
         """
         if not self._connected:
@@ -247,7 +247,7 @@ class StreamPipeline:
 
         Example:
             events = await pipeline.consume_events(
-                'events:commands',
+                'events:process',
                 'router-group',
                 'router-1'
             )
@@ -322,7 +322,7 @@ class StreamPipeline:
 
         Example:
             success = await pipeline.acknowledge_event(
-                'events:commands',
+                'events:process',
                 'router-group',
                 '1234567890-0'
             )
@@ -374,10 +374,10 @@ class StreamPipeline:
 
         Example:
             success = await pipeline.move_to_dlq(
-                'events:commands',
+                'events:process',
                 '1234567890-0',
                 'max_retries_exceeded',
-                event_data={'command': 'translate'},
+                event_data={'type': 'translate'},
                 retry_count=3
             )
         """
@@ -435,7 +435,7 @@ class StreamPipeline:
 
         Example:
             success = await pipeline.create_consumer_group(
-                'events:commands',
+                'events:process',
                 'router-group'
             )
         """
@@ -492,7 +492,7 @@ class StreamPipeline:
 
         Example:
             pending = await pipeline.get_pending_events(
-                'events:commands',
+                'events:process',
                 'router-group'
             )
             for event in pending:
@@ -541,7 +541,7 @@ class StreamPipeline:
             Stream info with length, first_entry, last_entry, consumer_groups, etc.
 
         Example:
-            info = await pipeline.get_stream_info('events:commands')
+            info = await pipeline.get_stream_info('events:process')
             print(f"Stream length: {info['length']}")
         """
         if not self._connected:
@@ -593,7 +593,7 @@ class StreamPipeline:
             List of DLQ events with id, data, original_id, failure_reason, etc.
 
         Example:
-            dlq_events = await pipeline.get_dlq_events('events:commands')
+            dlq_events = await pipeline.get_dlq_events('events:process')
             for event in dlq_events:
                 print(f"Failed: {event['failure_reason']}")
         """

--- a/libs/flask_core/pytest.ini
+++ b/libs/flask_core/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/libs/flask_core/tests/conftest.py
+++ b/libs/flask_core/tests/conftest.py
@@ -1,0 +1,205 @@
+"""Shared fixtures for flask_core tests.
+
+Provides an in-memory, async, redis.asyncio-compatible fake so
+StreamPipeline's generic contract can be exercised without a live
+Valkey/Redis server. Only the small Streams surface StreamPipeline
+actually calls is implemented.
+"""
+
+import importlib.util
+import itertools
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+import redis as redis_module
+
+
+def _load_stream_pipeline_module():
+    """Load stream_pipeline.py directly, bypassing flask_core/__init__.py.
+
+    The package __init__ eagerly imports every sibling module (database,
+    auth, cache, ...), pulling in pydal/sqlalchemy/flask-security-too that
+    this leaf-module unit test has no business depending on. stream_pipeline
+    itself only imports stdlib + optional `redis`, so it loads standalone.
+    """
+    module_name = "flask_core.stream_pipeline"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    src = Path(__file__).resolve().parent.parent / "flask_core" / "stream_pipeline.py"
+    spec = importlib.util.spec_from_file_location(module_name, src)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponseError(redis_module.ResponseError):
+    """Stand-in for redis.ResponseError so BUSYGROUP/no-such-key paths exercise real handling."""
+
+
+class _FakeStream:
+    """A single append-only stream plus its consumer groups."""
+
+    def __init__(self) -> None:
+        self.entries: List[Tuple[str, Dict[str, str]]] = []
+        self.groups: Dict[str, Dict[str, Any]] = {}
+
+
+class FakeAsyncRedis:
+    """Minimal in-memory async Redis Streams client.
+
+    Implements just enough of the redis.asyncio.Redis Streams surface
+    (xadd, xreadgroup, xack, xgroup_create, xpending_range, xinfo_stream,
+    xrange, xtrim, ping, close) for StreamPipeline's unit tests.
+    """
+
+    def __init__(self) -> None:
+        self._streams: Dict[str, _FakeStream] = {}
+        self._id_counter = itertools.count(1)
+
+    def _stream(self, name: str) -> _FakeStream:
+        return self._streams.setdefault(name, _FakeStream())
+
+    async def ping(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        return None
+
+    async def xadd(
+        self,
+        name: str,
+        fields: Dict[str, str],
+        maxlen: Optional[int] = None,
+        approximate: bool = True,
+    ) -> str:
+        stream = self._stream(name)
+        message_id = f"{next(self._id_counter)}-0"
+        stream.entries.append((message_id, dict(fields)))
+        if maxlen is not None and len(stream.entries) > maxlen:
+            stream.entries = stream.entries[-maxlen:]
+        return message_id
+
+    async def xgroup_create(
+        self, name: str, groupname: str, id: str = "0", mkstream: bool = False
+    ) -> bool:
+        stream = self._stream(name)
+        if groupname in stream.groups:
+            raise FakeResponseError("BUSYGROUP Consumer Group name already exists")
+        stream.groups[groupname] = {"last_delivered": 0, "pending": {}}
+        return True
+
+    async def xreadgroup(
+        self,
+        groupname: str,
+        consumername: str,
+        streams: Dict[str, str],
+        count: Optional[int] = None,
+        block: Optional[int] = None,
+    ) -> List[Tuple[str, List[Tuple[str, Dict[str, str]]]]]:
+        results: List[Tuple[str, List[Tuple[str, Dict[str, str]]]]] = []
+        for name in streams:
+            stream = self._stream(name)
+            group = stream.groups[groupname]
+            new_entries = stream.entries[group["last_delivered"]:]
+            if count is not None:
+                new_entries = new_entries[:count]
+            if not new_entries:
+                continue
+            delivered: List[Tuple[str, Dict[str, str]]] = []
+            for message_id, fields in new_entries:
+                group["pending"][message_id] = {
+                    "consumer": consumername,
+                    "times_delivered": group["pending"].get(message_id, {}).get(
+                        "times_delivered", 0
+                    )
+                    + 1,
+                }
+                delivered.append((message_id, fields))
+            group["last_delivered"] += len(new_entries)
+            results.append((name, delivered))
+        return results
+
+    async def xack(self, name: str, groupname: str, *ids: str) -> int:
+        stream = self._stream(name)
+        group = stream.groups.get(groupname, {"pending": {}})
+        acked = 0
+        for message_id in ids:
+            if message_id in group.get("pending", {}):
+                del group["pending"][message_id]
+                acked += 1
+        return acked
+
+    async def xpending_range(
+        self,
+        name: str,
+        groupname: str,
+        min: str,
+        max: str,
+        count: int,
+        consumername: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        stream = self._stream(name)
+        group = stream.groups.get(groupname, {"pending": {}})
+        result = []
+        for message_id, info in list(group.get("pending", {}).items())[:count]:
+            if consumername and info["consumer"] != consumername:
+                continue
+            result.append(
+                {
+                    "message_id": message_id,
+                    "consumer": info["consumer"],
+                    "time_since_delivered": 0,
+                    "times_delivered": info["times_delivered"],
+                }
+            )
+        return result
+
+    async def xinfo_stream(self, name: str) -> Dict[str, Any]:
+        if name not in self._streams or not self._streams[name].entries:
+            raise FakeResponseError("ERR no such key")
+        stream = self._streams[name]
+        return {
+            "length": len(stream.entries),
+            "radix-tree-keys": 0,
+            "radix-tree-nodes": 0,
+            "groups": len(stream.groups),
+            "last-generated-id": stream.entries[-1][0],
+            "first-entry": stream.entries[0],
+            "last-entry": stream.entries[-1],
+        }
+
+    async def xrange(
+        self, name: str, min: str = "-", max: str = "+", count: Optional[int] = None
+    ) -> List[Tuple[str, Dict[str, str]]]:
+        stream = self._stream(name)
+        entries = stream.entries
+        if count is not None:
+            entries = entries[:count]
+        return list(entries)
+
+    async def xtrim(self, name: str, maxlen: int, approximate: bool = True) -> int:
+        stream = self._stream(name)
+        removed = max(0, len(stream.entries) - maxlen)
+        stream.entries = stream.entries[-maxlen:]
+        return removed
+
+
+@pytest.fixture
+async def fake_redis() -> FakeAsyncRedis:
+    """A fresh in-memory fake Redis client per test."""
+    return FakeAsyncRedis()
+
+
+@pytest.fixture
+async def pipeline(fake_redis: FakeAsyncRedis):
+    """A connected StreamPipeline wired to the in-memory fake, bypassing real Redis I/O."""
+    StreamPipeline = _load_stream_pipeline_module().StreamPipeline
+
+    p = StreamPipeline(redis_url="redis://fake", enabled=True)
+    p._redis = fake_redis
+    p._connected = True
+    yield p
+    p._connected = False

--- a/libs/flask_core/tests/test_stream_pipeline.py
+++ b/libs/flask_core/tests/test_stream_pipeline.py
@@ -1,0 +1,117 @@
+"""Generic-contract tests for StreamPipeline (Task 0.3b: split the router).
+
+StreamPipeline is the Core event bus library — every stage links against it
+to publish/consume opaque events on Valkey/Redis Streams. It must carry zero
+platform or command vocabulary; callers (e.g. Bot's command_processor) own
+the meaning of an event's `type` field, the pipeline only moves bytes.
+"""
+
+import re
+from pathlib import Path
+
+STREAM_PIPELINE_SRC = (
+    Path(__file__).resolve().parent.parent / "flask_core" / "stream_pipeline.py"
+)
+
+
+def test_stream_pipeline_carries_no_domain_vocabulary() -> None:
+    """Regression guard for the router split: no Twitch/Discord/command/emote leakage.
+
+    Mirrors the plan's verify gate:
+    grep -riE "twitch|discord|emote|command" libs/flask_core/flask_core/stream_pipeline.py
+    """
+    text = STREAM_PIPELINE_SRC.read_text()
+    leaks = re.findall(r"twitch|discord|emote|command", text, re.IGNORECASE)
+    assert leaks == [], f"domain vocabulary leaked into the generic event bus: {leaks}"
+
+
+async def test_publish_consume_ack_roundtrip(pipeline) -> None:
+    """An opaque event type moves through publish -> consume -> ack cleanly."""
+    message_id = await pipeline.publish_event(
+        "events:process", {"type": "widget.created", "widget_id": "w-1"}
+    )
+    assert message_id is not None
+
+    events = await pipeline.consume_events(
+        "events:process", consumer_group="test-group", consumer_name="consumer-1"
+    )
+    assert len(events) == 1
+    assert events[0]["data"] == {"type": "widget.created", "widget_id": "w-1"}
+    assert events[0]["retry_count"] == 0
+
+    acked = await pipeline.acknowledge_event(
+        "events:process", consumer_group="test-group", message_id=events[0]["id"]
+    )
+    assert acked is True
+
+    # Acked message is no longer pending redelivery.
+    pending = await pipeline.get_pending_events(
+        "events:process", consumer_group="test-group"
+    )
+    assert pending == []
+
+
+async def test_unacked_event_remains_pending_until_acked(pipeline) -> None:
+    """A consumed-but-not-acked event stays in the pending entries list (at-least-once)."""
+    await pipeline.publish_event("events:process", {"type": "widget.created"})
+    events = await pipeline.consume_events(
+        "events:process", consumer_group="test-group", consumer_name="consumer-1"
+    )
+    assert len(events) == 1
+
+    pending = await pipeline.get_pending_events(
+        "events:process", consumer_group="test-group"
+    )
+    assert len(pending) == 1
+    assert pending[0]["message_id"] == events[0]["id"]
+
+
+async def test_poison_event_moves_to_dlq(pipeline) -> None:
+    """A poison event lands in the DLQ with its failure reason and original payload."""
+    await pipeline.publish_event("events:process", {"type": "widget.created"})
+    events = await pipeline.consume_events(
+        "events:process", consumer_group="test-group", consumer_name="consumer-1"
+    )
+    assert len(events) == 1
+    event = events[0]
+
+    moved = await pipeline.move_to_dlq(
+        "events:process",
+        message_id=event["id"],
+        error_reason="max_retries_exceeded",
+        event_data=event["data"],
+        retry_count=3,
+    )
+    assert moved is True
+
+    await pipeline.acknowledge_event(
+        "events:process", consumer_group="test-group", message_id=event["id"]
+    )
+
+    dlq_events = await pipeline.get_dlq_events("events:process")
+    assert len(dlq_events) == 1
+    assert dlq_events[0]["failure_reason"] == "max_retries_exceeded"
+    assert dlq_events[0]["original_id"] == event["id"]
+    assert dlq_events[0]["data"] == {"type": "widget.created"}
+
+    # Original stream's pending list is clear — the poison event isn't retried forever.
+    pending = await pipeline.get_pending_events(
+        "events:process", consumer_group="test-group"
+    )
+    assert pending == []
+
+
+async def test_consumer_group_creation_is_idempotent(pipeline) -> None:
+    """Re-consuming re-creates the group without raising (BUSYGROUP handled internally)."""
+    await pipeline.publish_event("events:process", {"type": "widget.created"})
+    first = await pipeline.consume_events(
+        "events:process", consumer_group="test-group", consumer_name="consumer-1"
+    )
+    assert len(first) == 1
+
+    # Second call creates the same group again — must not raise, must not redeliver
+    # anything new since nothing else was published.
+    second = await pipeline.consume_events(
+        "events:process", consumer_group="test-group", consumer_name="consumer-2"
+    )
+    assert second == []


### PR DESCRIPTION
Task 0.3b. The Core event bus is the existing `flask_core.StreamPipeline` library, not a new service. It was 99% domain-agnostic; one real leak (`STREAM_COMMANDS = events:commands` constant + docstrings) renamed to `STREAM_PROCESS`. Nothing references the library attribute (router's command stream is its own env-driven config). Grep gate clean. New flask_core test suite (5/5, fail-first proven). 15-line change.