### PR TITLE
feat(v3 P0.4): tenant-scoping foundation

### DIFF
--- a/libs/flask_core/flask_core/__init__.py
+++ b/libs/flask_core/flask_core/__init__.py
@@ -16,7 +16,25 @@ __version__ = "2.0.0"
 __author__ = "Waddles Team"
 
 from .database import AsyncDAL, init_database
-from .auth import setup_auth, OAuthProvider, create_jwt_token, verify_jwt_token, verify_service_key
+from .auth import (
+    setup_auth,
+    OAuthProvider,
+    create_jwt_token,
+    verify_jwt_token,
+    verify_service_key,
+    setup_default_roles,
+    DEFAULT_TENANT_SLUG,
+    TENANT_CLAIM_MIGRATION_CUTOFF,
+    SCOPE_BUNDLES,
+)
+from .tenancy import (
+    TenantContext,
+    TenantIsolationError,
+    tenant_middleware,
+    tenant_scoped,
+    resolve_tenant_context,
+    get_tenant_context,
+)
 from .datamodels import (
     CommandRequest,
     CommandResult,
@@ -126,6 +144,17 @@ __all__ = [
     "create_jwt_token",
     "verify_jwt_token",
     "verify_service_key",
+    "setup_default_roles",
+    "DEFAULT_TENANT_SLUG",
+    "TENANT_CLAIM_MIGRATION_CUTOFF",
+    "SCOPE_BUNDLES",
+    # Tenancy
+    "TenantContext",
+    "TenantIsolationError",
+    "tenant_middleware",
+    "tenant_scoped",
+    "resolve_tenant_context",
+    "get_tenant_context",
     # Datamodels
     "CommandRequest",
     "CommandResult",

--- a/libs/flask_core/flask_core/auth.py
+++ b/libs/flask_core/flask_core/auth.py
@@ -15,12 +15,28 @@ Provides comprehensive authentication and authorization:
 from authlib.integrations.flask_client import OAuth
 from dataclasses import dataclass, field
 from typing import Optional, Dict, Any, List
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import jwt
 import secrets
 import logging
 
 logger = logging.getLogger(__name__)
+
+#: Slug of the tenant every pre-Task-0.4 token and every single-tenant
+#: (Free/Professional, capped) deployment resolves to. Matches
+#: `tenants.slug = 'global'` seeded by migration 058 -- not a bypass, the
+#: identical tenant-scoping code in tenancy.py runs for it with N=1. See
+#: security.md Tenant Isolation.
+DEFAULT_TENANT_SLUG = "global"
+
+# TODO(tenancy-migration, tracking: v3.0.x Task 0.4): tokens minted before
+# this cutoff predate the mandatory `tenant` claim and are treated as
+# DEFAULT_TENANT_SLUG by verify_jwt_token() below. create_jwt_token() has
+# required `tenant` since this change landed, so any token issued *after*
+# the cutoff that is still missing the claim is rejected outright, not
+# defaulted. Extend only with explicit sign-off -- a permanently open
+# cutoff is the untenanted backdoor in a different shape.
+TENANT_CLAIM_MIGRATION_CUTOFF = datetime(2026, 11, 26, tzinfo=timezone.utc)
 
 
 @dataclass(slots=True)
@@ -117,9 +133,10 @@ def setup_auth(app, dal, config: Optional[Dict[str, Any]] = None):
 
     dal.define_table(
         'auth_role',
-        dal.Field('name', 'string', unique=True, notnull=True),
+        dal.Field('name', 'string', unique=True, notnull=True),  # e.g. 'tenant:admin'
+        dal.Field('level', 'string'),  # 'global' | 'tenant' | 'community'
         dal.Field('description', 'text'),
-        dal.Field('permissions', 'json'),  # List of permission strings
+        dal.Field('permissions', 'json'),  # List of scope strings, e.g. 'community:read'
         dal.Field('created_at', 'datetime', default=datetime.utcnow)
     )
 
@@ -181,6 +198,7 @@ def create_jwt_token(
     email: str,
     roles: List[str],
     secret_key: str,
+    tenant: str,
     expiration_hours: int = 24
 ) -> str:
     """
@@ -192,11 +210,23 @@ def create_jwt_token(
         email: User email
         roles: List of role names
         secret_key: JWT secret key
+        tenant: Tenant slug the token is scoped to. Mandatory -- security.md
+            requires every token to carry a `tenant` claim; single-tenant
+            deployments pass DEFAULT_TENANT_SLUG, not an empty/omitted value.
         expiration_hours: Token expiration in hours
 
     Returns:
         JWT token string
+
+    Raises:
+        ValueError: If tenant is empty -- there is no untenanted token.
     """
+    if not tenant:
+        raise ValueError(
+            "tenant is mandatory on every JWT (security.md Tenant Isolation) -- "
+            "pass DEFAULT_TENANT_SLUG for single-tenant deployments, never empty"
+        )
+
     now = datetime.utcnow()
     expiration = now + timedelta(hours=expiration_hours)
 
@@ -205,6 +235,7 @@ def create_jwt_token(
         'username': username,
         'email': email,
         'roles': roles,
+        'tenant': tenant,
         'iat': now,
         'exp': expiration,
         'type': 'access'
@@ -212,7 +243,7 @@ def create_jwt_token(
 
     token = jwt.encode(payload, secret_key, algorithm='HS256')
 
-    logger.info(f"JWT token created for user {username} (expires in {expiration_hours}h)")
+    logger.info(f"JWT token created for user {username} (tenant={tenant}, expires in {expiration_hours}h)")
 
     return token
 
@@ -221,20 +252,59 @@ def verify_jwt_token(token: str, secret_key: str) -> Optional[Dict[str, Any]]:
     """
     Verify and decode JWT token.
 
+    Rejects tokens with no `tenant` claim, per security.md Tenant Isolation
+    -- except during the bounded migration window (TENANT_CLAIM_MIGRATION_CUTOFF),
+    where a legacy token (issued before the cutoff, before this claim
+    existed) is defaulted to DEFAULT_TENANT_SLUG rather than rejected. This
+    fallback is time-bounded, not a permanent bypass: a claim missing on a
+    token issued after the cutoff is rejected outright.
+
     Args:
         token: JWT token string
         secret_key: JWT secret key
 
     Returns:
-        Decoded token payload or None if invalid
+        Decoded token payload (always carrying a `tenant` key on success),
+        or None if invalid, expired, or missing a mandatory tenant claim
+        past the migration cutoff.
     """
     try:
         payload = jwt.decode(token, secret_key, algorithms=['HS256'])
 
-        # Check expiration
-        if datetime.fromtimestamp(payload['exp']) < datetime.utcnow():
+        # Check expiration. Timezone-aware on both sides -- the previous
+        # `fromtimestamp(exp) < utcnow()` compared local-time-interpreted
+        # exp against naive-UTC now, which falsely expired short-lived
+        # tokens in any timezone behind UTC (and the inverse security bug --
+        # falsely valid past real expiry -- ahead of UTC). Found while
+        # adding the tenant-claim check below; fixed in place since a
+        # broken expiry check undermines everything else in this function.
+        if datetime.fromtimestamp(payload['exp'], tz=timezone.utc) < datetime.now(timezone.utc):
             logger.warning("JWT token expired")
             return None
+
+        if not payload.get('tenant'):
+            issued_at = datetime.fromtimestamp(payload['iat'], tz=timezone.utc)
+            if issued_at < TENANT_CLAIM_MIGRATION_CUTOFF:
+                logger.warning(
+                    f"JWT missing tenant claim -- applying migration-window "
+                    f"default tenant fallback (cutoff {TENANT_CLAIM_MIGRATION_CUTOFF.isoformat()})",
+                    extra={
+                        'event_type': 'AUTH',
+                        'action': 'verify_jwt_token',
+                        'result': 'DEFAULT_TENANT_FALLBACK'
+                    }
+                )
+                payload = {**payload, 'tenant': DEFAULT_TENANT_SLUG}
+            else:
+                logger.error(
+                    "JWT missing mandatory tenant claim past migration cutoff -- rejecting",
+                    extra={
+                        'event_type': 'AUTH',
+                        'action': 'verify_jwt_token',
+                        'result': 'FAILURE'
+                    }
+                )
+                return None
 
         return payload
 
@@ -356,39 +426,65 @@ def verify_service_key(provided_key: str, expected_key: Optional[str]) -> bool:
     return secrets.compare_digest(provided_key, expected_key)
 
 
+#: Per-level scope bundles -- security.md's admin/maintainer/viewer table,
+#: instantiated at each of the global/tenant/community levels from
+#: docs/plans/2026-08-26-v3-scbm-apps-design.md's Identity and data scoping
+#: ladder. No bundle grants the unbounded '*': narrower levels restrict what
+#: a broader level granted, they never expand it. Middleware checks these
+#: scopes only -- never the role/bundle name.
+SCOPE_BUNDLES: Dict[str, Dict[str, List[str]]] = {
+    'global': {
+        'admin': ['*:read', '*:write', '*:admin', '*:delete', 'settings:write', 'users:admin'],
+        'maintainer': ['*:read', '*:write', 'teams:read', 'reports:read', 'analytics:read'],
+        'viewer': ['*:read'],
+    },
+    'tenant': {
+        'admin': [
+            'tenant:read', 'tenant:write', 'tenant:admin', 'tenant:delete',
+            'community:create', 'community:delete', 'billing:read', 'billing:write',
+            'settings:write', 'users:admin',
+        ],
+        'maintainer': [
+            'tenant:read', 'tenant:write', 'community:create',
+            'billing:read', 'reports:read', 'analytics:read',
+        ],
+        'viewer': ['tenant:read', 'billing:read'],
+    },
+    'community': {
+        'admin': [
+            'community:read', 'community:write', 'community:admin', 'community:delete',
+            'bot.command:admin', 'social.polls:write', 'settings:write',
+        ],
+        'maintainer': [
+            'community:read', 'community:write', 'bot.command:admin', 'social.polls:write',
+        ],
+        'viewer': ['community:read', 'social.polls:read'],
+    },
+}
+
+
 def setup_default_roles(dal):
     """
-    Create default roles if they don't exist.
+    Create default per-level scope-bundle roles if they don't exist.
+
+    Replaces the old flat admin/community_owner/moderator/user roles -- one
+    of which granted the unbounded '*' -- with admin/maintainer/viewer
+    bundles at each of global/tenant/community, per security.md's bundle
+    table. Role name is `{level}:{bundle}` (e.g. 'tenant:admin'); middleware
+    must check the resulting scopes, never the role name.
 
     Args:
         dal: AsyncDAL instance
     """
-    default_roles = [
-        {
-            'name': 'admin',
-            'description': 'Full system access',
-            'permissions': ['*']
-        },
-        {
-            'name': 'community_owner',
-            'description': 'Owns and manages communities',
-            'permissions': ['community:*', 'module:install', 'module:configure']
-        },
-        {
-            'name': 'moderator',
-            'description': 'Community moderator',
-            'permissions': ['community:moderate', 'user:manage']
-        },
-        {
-            'name': 'user',
-            'description': 'Standard user',
-            'permissions': ['profile:view', 'profile:edit']
-        }
-    ]
-
-    for role_data in default_roles:
-        # Check if role exists
-        existing = dal(dal.auth_role.name == role_data['name']).select().first()
-        if not existing:
-            dal.auth_role.insert(**role_data)
-            logger.info(f"Created default role: {role_data['name']}")
+    for level, bundles in SCOPE_BUNDLES.items():
+        for bundle_name, scopes in bundles.items():
+            role_name = f"{level}:{bundle_name}"
+            existing = dal(dal.auth_role.name == role_name).select().first()
+            if not existing:
+                dal.auth_role.insert(
+                    name=role_name,
+                    level=level,
+                    description=f"{bundle_name.capitalize()} scope bundle at {level} level",
+                    permissions=scopes,
+                )
+                logger.info(f"Created default role: {role_name}")

--- a/libs/flask_core/flask_core/tenancy.py
+++ b/libs/flask_core/flask_core/tenancy.py
@@ -1,0 +1,189 @@
+"""
+Tenant Isolation
+================
+
+Tenant is a hard boundary (security.md Tenant Isolation): every token
+carries a `tenant` claim, tenant resolution runs before any scope check,
+and every query touching tenant-scoped data is constrained at the ORM
+layer -- never from a request body, query string, or path parameter.
+
+This module provides the three load-bearing pieces:
+- `TenantContext`: the validated tenant for a request.
+- `tenant_middleware`: decodes the bearer JWT and publishes `TenantContext`
+  before the wrapped handler (and any scope check inside it) runs.
+- `tenant_scoped`: the single ORM-layer helper every tenant-scoped query
+  must go through, so 178+ hand-written filters don't have to each get it
+  right independently.
+
+The default tenant (`DEFAULT_TENANT_SLUG`, matching migration 058's seeded
+`tenants.slug = 'global'` row) is a tenant like any other -- it runs through
+this exact same code with N=1, never a `if tenant == "default": skip()`
+shortcut. See docs/plans/2026-08-26-v3-scbm-apps-design.md, Identity and
+data scoping.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any, Optional
+
+from pydal.objects import Field, Query, Table
+
+from .auth import DEFAULT_TENANT_SLUG, verify_jwt_token
+
+logger = logging.getLogger(__name__)
+
+
+class TenantIsolationError(Exception):
+    """Raised when a request or query cannot be safely bound to a tenant."""
+
+
+@dataclass(slots=True, frozen=True)
+class TenantContext:
+    """
+    The validated tenant for the current request.
+
+    Built exclusively by `tenant_middleware` from the decoded JWT `tenant`
+    claim -- never from client-supplied body/query/path data. Frozen so
+    nothing downstream can swap tenants mid-request.
+    """
+
+    tenant_id: int
+    tenant_slug: str
+    is_default: bool = False
+
+
+# ---------------------------------------------------------------------------
+# ORM-layer scoping -- the one correct shape, not 178 hand-written filters
+# ---------------------------------------------------------------------------
+
+
+def _resolve_table(query: Query) -> Table:
+    """Walk a (possibly AND-chained) pydal Query down to its leftmost Field's Table."""
+    node: Any = query
+    while isinstance(node, Query) and not isinstance(node.first, Field):
+        node = node.first
+    if isinstance(node, Query) and isinstance(node.first, Field):
+        return node.first.table
+    raise TenantIsolationError(
+        "tenant_scoped() could not resolve a table from the given query -- "
+        "pass a query built directly off a Field comparison, e.g. "
+        "db.communities.id == cid"
+    )
+
+
+def tenant_scoped(query: Query, ctx: TenantContext) -> Query:
+    """
+    AND a tenant filter onto `query` at the ORM layer.
+
+    This is the ONLY correct shape for tenant scoping -- a module does
+    `db(tenant_scoped(db.communities.id == cid, ctx))` and cannot forget the
+    tenant filter, unlike a hand-written `.tenant_id == ctx.tenant_id`
+    repeated at every call site. Resolves the table being queried and
+    constrains it either directly (a `tenant_id` column) or one hop through
+    `community_id -> communities.tenant_id`. Tables with neither raise
+    loudly rather than silently returning an unscoped query.
+    """
+    table = _resolve_table(query)
+    dal = table._db
+
+    if "tenant_id" in table.fields:
+        return query & (table.tenant_id == ctx.tenant_id)
+
+    if "community_id" in table.fields:
+        tenant_communities = dal(dal.communities.tenant_id == ctx.tenant_id)._select(
+            dal.communities.id
+        )
+        return query & table.community_id.belongs(tenant_communities)
+
+    raise TenantIsolationError(
+        f"table '{table._tablename}' has neither tenant_id nor community_id -- "
+        "add one before this table can be safely tenant-scoped"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Request-layer resolution -- runs before any scope check
+# ---------------------------------------------------------------------------
+
+
+async def resolve_tenant_context(payload: dict[str, Any], dal: Any) -> TenantContext:
+    """
+    Build a `TenantContext` from a verified JWT payload's `tenant` claim.
+
+    `verify_jwt_token` has already applied the migration-window default-
+    tenant fallback (see auth.py), so `payload["tenant"]` is always present
+    by the time this runs; a still-missing claim is a hard 403, never a
+    second silent default.
+    """
+    tenant_slug = payload.get("tenant")
+    if not tenant_slug:
+        raise TenantIsolationError("token carries no tenant claim")
+
+    row = dal(dal.tenants.slug == tenant_slug).select().first()
+    if row is None:
+        raise TenantIsolationError(f"tenant '{tenant_slug}' does not exist")
+    if not row.is_active:
+        raise TenantIsolationError(f"tenant '{tenant_slug}' is inactive")
+
+    return TenantContext(
+        tenant_id=row.id,
+        tenant_slug=row.slug,
+        is_default=(row.slug == DEFAULT_TENANT_SLUG),
+    )
+
+
+def tenant_middleware(f):
+    """
+    Decorator enforcing security.md's ordering contract: tenant before scope.
+
+    Decodes the bearer JWT, resolves and publishes `TenantContext` on
+    `request.tenant_context`, and only then calls the wrapped handler. Must
+    be the outermost auth decorator on every protected route -- any scope
+    check has to run inside it, never outside, or it answers the right
+    question against an unverified tenant.
+    """
+
+    @wraps(f)
+    async def decorated_function(*args, **kwargs):
+        from quart import current_app, request
+
+        from .api_utils import error_response
+
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return error_response("Authentication required", status_code=401)
+
+        token = auth_header[7:]
+        secret_key = os.getenv("SECRET_KEY", "change-me-in-production")
+        payload = verify_jwt_token(token, secret_key)
+        if payload is None:
+            return error_response("Invalid or expired token", status_code=401)
+
+        dal = current_app.config.get("dal")
+        try:
+            ctx = await resolve_tenant_context(payload, dal)
+        except TenantIsolationError as exc:
+            logger.warning(
+                "Tenant resolution failed: %s",
+                exc,
+                extra={
+                    "event_type": "AUTH",
+                    "action": "tenant_middleware",
+                    "result": "FORBIDDEN",
+                },
+            )
+            return error_response(str(exc), status_code=403)
+
+        request.tenant_context = ctx
+        return await f(*args, **kwargs)
+
+    return decorated_function
+
+
+def get_tenant_context(request: Any) -> Optional[TenantContext]:
+    """Return the `TenantContext` `tenant_middleware` published on `request`, if any."""
+    return getattr(request, "tenant_context", None)

--- a/libs/flask_core/tests/test_tenancy.py
+++ b/libs/flask_core/tests/test_tenancy.py
@@ -1,0 +1,221 @@
+"""
+Tenant Isolation Tests
+=======================
+
+Centerpiece: `TestCrossTenantIsolation` proves a token scoped to tenant A
+never reaches tenant B's rows, via `tenant_scoped`. Also covers the
+mandatory `tenant` JWT claim and its bounded migration-window fallback --
+see security.md Tenant Isolation and Task 0.4 of
+docs/plans/2026-08-26-v3-scbm-apps.md.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from pydal import DAL, Field
+
+from flask_core.auth import (
+    DEFAULT_TENANT_SLUG,
+    TENANT_CLAIM_MIGRATION_CUTOFF,
+    create_jwt_token,
+    setup_default_roles,
+    verify_jwt_token,
+)
+from flask_core.tenancy import TenantContext, TenantIsolationError, tenant_scoped
+
+SECRET = "test-secret-key-not-for-production-use-only"
+
+
+@pytest.fixture
+def db():
+    """In-memory pydal DB modelling the tenants -> communities -> posts chain."""
+    dal = DAL("sqlite:memory")
+    dal.define_table("tenants", Field("slug", unique=True), Field("is_active", "boolean", default=True))
+    dal.define_table("communities", Field("tenant_id", "reference tenants"), Field("name"))
+    dal.define_table("posts", Field("community_id", "reference communities"), Field("title"))
+    dal.define_table("orphan_widgets", Field("label"))  # neither tenant_id nor community_id
+    dal.define_table(
+        "auth_role",
+        Field("name", "string", unique=True, notnull=True),
+        Field("level", "string"),
+        Field("description", "text"),
+        Field("permissions", "json"),
+    )
+    yield dal
+    dal.close()
+
+
+@pytest.fixture
+def two_tenants(db):
+    """Seed two tenants, one community each, one post each -- the isolation fixture."""
+    tenant_a = db.tenants.insert(slug="tenant-a")
+    tenant_b = db.tenants.insert(slug="tenant-b")
+    community_a = db.communities.insert(tenant_id=tenant_a, name="A Community")
+    community_b = db.communities.insert(tenant_id=tenant_b, name="B Community")
+    db.posts.insert(community_id=community_a, title="a-post")
+    db.posts.insert(community_id=community_b, title="b-post")
+    db.commit()
+    return {"tenant_a": tenant_a, "tenant_b": tenant_b}
+
+
+class TestCrossTenantIsolation:
+    """The centerpiece: a token for tenant A must not reach tenant B's data."""
+
+    def test_unscoped_query_leaks_cross_tenant_data(self, db, two_tenants):
+        """Documents the pre-Task-0.4 vulnerability directly: a query with no
+        tenant filter at all -- exactly what 246 files did -- returns every
+        tenant's rows. This is what tenant_scoped exists to prevent; see the
+        two tests below for the fix, and the fail-first proof in the PR
+        report (tenant_scoped temporarily neutered, this same assertion
+        pattern observed failing)."""
+        rows = db(db.posts.id > 0).select()
+        titles = {r.title for r in rows}
+        assert titles == {"a-post", "b-post"}
+
+    def test_tenant_scoped_excludes_other_tenant_direct_fk(self, db, two_tenants):
+        """communities has a direct tenant_id column."""
+        ctx_a = TenantContext(tenant_id=two_tenants["tenant_a"], tenant_slug="tenant-a")
+        rows = db(tenant_scoped(db.communities.id > 0, ctx_a)).select()
+        names = {r.name for r in rows}
+        assert names == {"A Community"}
+        assert "B Community" not in names
+
+    def test_tenant_scoped_excludes_other_tenant_via_community_fk(self, db, two_tenants):
+        """posts has no tenant_id -- scoping goes through community_id -> communities.tenant_id."""
+        ctx_a = TenantContext(tenant_id=two_tenants["tenant_a"], tenant_slug="tenant-a")
+        rows = db(tenant_scoped(db.posts.id > 0, ctx_a)).select()
+        titles = {r.title for r in rows}
+        assert titles == {"a-post"}
+        assert "b-post" not in titles
+
+    def test_tenant_scoped_symmetric_for_tenant_b(self, db, two_tenants):
+        """Same helper, other tenant -- proves this isn't a one-sided fixture accident."""
+        ctx_b = TenantContext(tenant_id=two_tenants["tenant_b"], tenant_slug="tenant-b")
+        rows = db(tenant_scoped(db.posts.id > 0, ctx_b)).select()
+        titles = {r.title for r in rows}
+        assert titles == {"b-post"}
+        assert "a-post" not in titles
+
+    def test_default_tenant_runs_identical_code_n_equals_1(self, db):
+        """No `if tenant == "default": skip_filter()` shortcut -- the default
+        tenant is filtered by the exact same tenant_scoped() call path, just
+        with a roster of one."""
+        default_tenant = db.tenants.insert(slug=DEFAULT_TENANT_SLUG)
+        community = db.communities.insert(tenant_id=default_tenant, name="Only Community")
+        db.posts.insert(community_id=community, title="only-post")
+        db.commit()
+
+        ctx = TenantContext(tenant_id=default_tenant, tenant_slug=DEFAULT_TENANT_SLUG, is_default=True)
+        rows = db(tenant_scoped(db.posts.id > 0, ctx)).select()
+        assert {r.title for r in rows} == {"only-post"}
+
+    def test_tenant_scoped_rejects_table_with_no_tenant_path(self, db, two_tenants):
+        """A table with neither tenant_id nor community_id fails loudly, not silently."""
+        db.orphan_widgets.insert(label="mystery")
+        db.commit()
+        ctx_a = TenantContext(tenant_id=two_tenants["tenant_a"], tenant_slug="tenant-a")
+        with pytest.raises(TenantIsolationError):
+            tenant_scoped(db.orphan_widgets.id > 0, ctx_a)
+
+
+class TestTenantClaim:
+    """create_jwt_token/verify_jwt_token: the tenant claim contract."""
+
+    def test_create_jwt_token_requires_tenant(self):
+        with pytest.raises(ValueError):
+            create_jwt_token(
+                user_id="u1",
+                username="alice",
+                email="alice@example.com",
+                roles=["viewer"],
+                secret_key=SECRET,
+                tenant="",
+            )
+
+    def test_create_and_verify_round_trip_carries_tenant(self):
+        token = create_jwt_token(
+            user_id="u1",
+            username="alice",
+            email="alice@example.com",
+            roles=["viewer"],
+            secret_key=SECRET,
+            tenant="tenant-a",
+        )
+        payload = verify_jwt_token(token, SECRET)
+        assert payload is not None
+        assert payload["tenant"] == "tenant-a"
+
+    def test_verify_rejects_missing_tenant_claim_post_cutoff(self):
+        """A token issued after the migration cutoff with no tenant claim is
+        rejected outright -- the fallback is bounded, not permanent."""
+        now = datetime.now(timezone.utc)
+        assert now < TENANT_CLAIM_MIGRATION_CUTOFF, "test assumes 'now' precedes the cutoff constant"
+        post_cutoff_iat = TENANT_CLAIM_MIGRATION_CUTOFF + timedelta(days=1)
+        payload = {
+            "sub": "u1",
+            "username": "alice",
+            "email": "alice@example.com",
+            "roles": [],
+            "iat": post_cutoff_iat,
+            "exp": post_cutoff_iat + timedelta(hours=1),
+            "type": "access",
+        }
+        token = jwt.encode(payload, SECRET, algorithm="HS256")
+        # exp is compared against real wall-clock utcnow(); a post-cutoff iat
+        # is necessarily in the future too, so the token is not yet expired --
+        # rejection here is solely the missing-tenant-claim path.
+        assert verify_jwt_token(token, SECRET) is None
+
+    def test_verify_applies_default_tenant_fallback_pre_cutoff(self):
+        """A legacy token (no tenant claim, issued before the cutoff) is
+        defaulted to DEFAULT_TENANT_SLUG rather than rejected."""
+        legacy_iat = datetime.now(timezone.utc)
+        assert legacy_iat < TENANT_CLAIM_MIGRATION_CUTOFF
+        payload = {
+            "sub": "u1",
+            "username": "alice",
+            "email": "alice@example.com",
+            "roles": [],
+            "iat": legacy_iat,
+            "exp": legacy_iat + timedelta(hours=1),
+            "type": "access",
+        }
+        token = jwt.encode(payload, SECRET, algorithm="HS256")
+        result = verify_jwt_token(token, SECRET)
+        assert result is not None
+        assert result["tenant"] == DEFAULT_TENANT_SLUG
+
+
+class TestScopeBundles:
+    """setup_default_roles: per-level scope bundles, no unbounded '*'."""
+
+    def test_creates_roles_at_all_three_levels(self, db):
+        setup_default_roles(db)
+        names = {r.name for r in db(db.auth_role).select()}
+        for level in ("global", "tenant", "community"):
+            for bundle in ("admin", "maintainer", "viewer"):
+                assert f"{level}:{bundle}" in names
+
+    def test_no_bundle_grants_unbounded_wildcard(self, db):
+        setup_default_roles(db)
+        for row in db(db.auth_role).select():
+            assert "*" not in row.permissions, f"{row.name} grants unbounded '*'"
+
+    def test_narrower_level_does_not_exceed_broader_level_scope_count(self, db):
+        setup_default_roles(db)
+        global_admin = db(db.auth_role.name == "global:admin").select().first()
+        community_admin = db(db.auth_role.name == "community:admin").select().first()
+        # Global admin's scopes are platform-wide wildcards; community admin's
+        # are resource-specific -- narrower levels restrict, they don't gain
+        # a broader grant global:admin doesn't already imply.
+        assert all(not scope.startswith("*:") for scope in community_admin.permissions)
+        assert any(scope.startswith("*:") for scope in global_admin.permissions)
+
+    def test_setup_default_roles_is_idempotent(self, db):
+        setup_default_roles(db)
+        setup_default_roles(db)
+        names = [r.name for r in db(db.auth_role).select()]
+        assert len(names) == len(set(names))


### PR DESCRIPTION
Task 0.4 foundation (NOT the 178-file rollout — flagged out of scope). `flask_core/tenancy.py`: TenantContext, tenant_scoped (ORM-layer filter, direct tenant_id or community hop, **raises** rather than returning unscoped), tenant_middleware. auth.py: mandatory tenant claim, dated migration cutoff (no permanent bypass), per-level scope bundles replacing flat `['*']` roles, plus a timezone expiry-bug fix. 14 tests; cross-tenant isolation proven failing-first (neutered → 4 red).