### PR TITLE
chore(v3 P0.7): compliance plumbing — stream retention, PII allowlist, SBOM

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -167,3 +167,15 @@ jobs:
           echo "**Image:** \`${IMAGE}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Tag:** \`${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Platforms:** linux/amd64, linux/arm64" >> "$GITHUB_STEP_SUMMARY"
+
+      # CRA (EU Cyber Resilience Act): SBOM per built image. Generate +
+      # upload only for now — not a gating step until a policy is defined.
+      - name: Generate SBOM (SPDX)
+        id: sbom
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26  # v0.24.2
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ inputs.module_name }}:${{ needs.determine-version.outputs.version }}${{ needs.determine-version.outputs.suffix }}
+          format: spdx-json
+          output-file: sbom-${{ inputs.module_name }}.spdx.json
+          upload-artifact: true
+          upload-artifact-retention: 90

--- a/libs/flask_core/flask_core/stream_pipeline.py
+++ b/libs/flask_core/flask_core/stream_pipeline.py
@@ -66,6 +66,12 @@ class StreamPipeline:
     STREAM_ACTIONS = "events:actions"
     STREAM_RESPONSES = "events:responses"
 
+    # GDPR: unbounded streams are an unbounded retention period. This is the
+    # default applied to every stream write that does not pass an explicit
+    # bound (main streams already require callers to pass max_len; the DLQ
+    # bound lives here since poison events otherwise sit the longest).
+    DEFAULT_DLQ_MAXLEN = 10000
+
     def __init__(
         self,
         redis_url: Optional[str] = None,
@@ -74,7 +80,8 @@ class StreamPipeline:
         max_retries: Optional[int] = None,
         batch_size: Optional[int] = None,
         block_ms: Optional[int] = None,
-        enabled: Optional[bool] = None
+        enabled: Optional[bool] = None,
+        dlq_maxlen: Optional[int] = None
     ):
         """
         Initialize stream pipeline.
@@ -87,6 +94,10 @@ class StreamPipeline:
             batch_size: Events per batch (from env or default: 10)
             block_ms: Block time in ms (from env or default: 5000)
             enabled: Enable pipeline (from env or default: False)
+            dlq_maxlen: Maximum DLQ length before oldest entries are trimmed
+                (from env STREAM_DLQ_MAXLEN or default: 10000). GDPR
+                retention-period control for the dead letter queue, which
+                is otherwise an unbounded append-only log.
         """
         self.redis_url = redis_url
         self.stream_prefix = stream_prefix
@@ -97,6 +108,9 @@ class StreamPipeline:
         self.max_retries = max_retries if max_retries is not None else int(os.getenv('STREAM_MAX_RETRIES', '3'))
         self.batch_size = batch_size if batch_size is not None else int(os.getenv('STREAM_BATCH_SIZE', '10'))
         self.block_ms = block_ms if block_ms is not None else int(os.getenv('STREAM_BLOCK_MS', '5000'))
+        self.dlq_maxlen = dlq_maxlen if dlq_maxlen is not None else int(
+            os.getenv('STREAM_DLQ_MAXLEN', str(self.DEFAULT_DLQ_MAXLEN))
+        )
 
         self._redis: Optional[redis.Redis] = None
         self._connected = False
@@ -105,7 +119,7 @@ class StreamPipeline:
         logger.info(
             f"StreamPipeline initialized: enabled={self.enabled}, "
             f"max_retries={self.max_retries}, batch_size={self.batch_size}, "
-            f"block_ms={self.block_ms}"
+            f"block_ms={self.block_ms}, dlq_maxlen={self.dlq_maxlen}"
         )
 
     @staticmethod
@@ -402,8 +416,15 @@ class StreamPipeline:
             if event_data:
                 dlq_data['data'] = json.dumps(event_data)
 
-            # Add to DLQ
-            dlq_id = await self._redis.xadd(dlq_name, dlq_data)
+            # Add to DLQ with a bounded length (GDPR retention control —
+            # poison events are the ones most likely to sit indefinitely
+            # in an unbounded log, so the DLQ must never be exempt).
+            dlq_id = await self._redis.xadd(
+                dlq_name,
+                dlq_data,
+                maxlen=self.dlq_maxlen,
+                approximate=True
+            )
 
             logger.warning(
                 f"Event {message_id} moved to DLQ: {error_reason} "
@@ -677,7 +698,8 @@ def create_stream_pipeline(
     max_retries: Optional[int] = None,
     batch_size: Optional[int] = None,
     block_ms: Optional[int] = None,
-    enabled: Optional[bool] = None
+    enabled: Optional[bool] = None,
+    dlq_maxlen: Optional[int] = None
 ) -> StreamPipeline:
     """
     Factory function to create a stream pipeline.
@@ -690,6 +712,7 @@ def create_stream_pipeline(
         batch_size: Events per batch
         block_ms: Block time in ms
         enabled: Enable pipeline
+        dlq_maxlen: Maximum DLQ length before trimming (default: 10000)
 
     Returns:
         Configured StreamPipeline instance
@@ -708,5 +731,6 @@ def create_stream_pipeline(
         max_retries=max_retries,
         batch_size=batch_size,
         block_ms=block_ms,
-        enabled=enabled
+        enabled=enabled,
+        dlq_maxlen=dlq_maxlen
     )

--- a/tests/streams/conftest.py
+++ b/tests/streams/conftest.py
@@ -1,0 +1,126 @@
+"""
+Pytest fixtures for flask_core stream-pipeline compliance tests.
+
+Loads `stream_pipeline.py` directly by file path so tests do not have to
+import the `flask_core` package (whose `__init__.py` pulls in pydal,
+authlib and other unrelated runtime deps not needed here). Provides a
+minimal in-memory async fake of `redis.asyncio.Redis` covering only the
+Streams commands `StreamPipeline` issues -- no new dependency is added;
+`redis` itself remains the only package required (already declared in
+`libs/flask_core/requirements.txt`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+import pytest_asyncio
+
+_STREAM_PIPELINE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "libs" / "flask_core" / "flask_core" / "stream_pipeline.py"
+)
+
+
+def _load_stream_pipeline_module():
+    """Import stream_pipeline.py by path, isolated from the flask_core package."""
+    module_name = "waddlebot_stream_pipeline_under_test"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, _STREAM_PIPELINE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+stream_pipeline = _load_stream_pipeline_module()
+
+
+class FakeAsyncRedis:
+    """In-memory async fake of redis.asyncio.Redis, Streams subset only.
+
+    Implements XADD (with real MAXLEN-trim semantics), XTRIM, XLEN and
+    XRANGE -- exactly what StreamPipeline calls -- so retention tests
+    exercise genuine eviction behaviour without a live Redis server. Not a
+    general Redis reimplementation: no consumer groups, no other types.
+    """
+
+    def __init__(self) -> None:
+        self._streams: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+        self._seq = 0
+
+    async def ping(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        return None
+
+    def _next_id(self) -> str:
+        self._seq += 1
+        return f"{self._seq}-0"
+
+    async def xadd(
+        self,
+        name: str,
+        fields: dict[str, Any],
+        maxlen: Optional[int] = None,
+        approximate: bool = True,
+        id: str = "*",
+    ) -> str:
+        entries = self._streams.setdefault(name, [])
+        entry_id = self._next_id() if id == "*" else id
+        entries.append((entry_id, dict(fields)))
+        if maxlen is not None and len(entries) > maxlen:
+            del entries[: len(entries) - maxlen]
+        return entry_id
+
+    async def xtrim(
+        self, name: str, maxlen: Optional[int] = None, approximate: bool = True
+    ) -> int:
+        entries = self._streams.get(name, [])
+        if maxlen is None or len(entries) <= maxlen:
+            return 0
+        trimmed = len(entries) - maxlen
+        del entries[:trimmed]
+        return trimmed
+
+    async def xlen(self, name: str) -> int:
+        return len(self._streams.get(name, []))
+
+    async def xrange(
+        self, name: str, min: str = "-", max: str = "+", count: Optional[int] = None
+    ) -> list[tuple[str, dict[str, Any]]]:
+        entries = self._streams.get(name, [])
+        return list(entries[:count]) if count is not None else list(entries)
+
+
+@pytest.fixture
+def fake_redis() -> FakeAsyncRedis:
+    """A fresh in-memory fake Redis for each test."""
+    return FakeAsyncRedis()
+
+
+@pytest.fixture
+def stream_pipeline_module():
+    """The stream_pipeline module under test, for constructing extra instances."""
+    return stream_pipeline
+
+
+@pytest_asyncio.fixture
+async def pipeline(fake_redis: FakeAsyncRedis):
+    """A StreamPipeline wired to the in-memory fake, pre-connected.
+
+    Bypasses `connect()` (which requires a real Redis TCP handshake) by
+    injecting the fake directly and marking the pipeline connected, the
+    same shape every stream_pipeline test needs.
+    """
+    p = stream_pipeline.StreamPipeline(redis_url="redis://fake", enabled=True)
+    p._redis = fake_redis
+    p._connected = True
+    return p

--- a/tests/streams/test_no_pii_in_envelope.py
+++ b/tests/streams/test_no_pii_in_envelope.py
@@ -1,0 +1,94 @@
+"""
+PII-tokenization guard for the stream envelope (`critical-rules.md` PII
+Tokenization).
+
+`waddles:t:{tenant}:{stage}` streams are append-only; GDPR erasure is only
+tractable if the envelope carries UUIDs/opaque references, never PII,
+since deleting a stream entry selectively is not a thing. This asserts
+the envelope's *field set* -- the wrapper StreamPipeline itself writes to
+Redis -- against an ALLOWLIST of permitted fields.
+
+Deliberately an allowlist, not a denylist of PII-looking names: a
+denylist passes for every field nobody thought of. Anything outside the
+allowlist fails the test, whether or not it looks like PII today.
+
+Scope: this covers the transport envelope StreamPipeline constructs
+(StreamEvent, and the dicts passed to XADD for the main stream and the
+DLQ). The opaque `data`/`event_data` payload it carries is a per-Feature
+business-layer concern (tokenization of `EventPayload`/`CommandRequest`
+in `datamodels.py`) tracked separately -- see report.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+# Permitted top-level fields for the StreamEvent envelope dataclass.
+# Every field here is transport metadata (an ID, a stream name, a retry
+# counter, a timestamp) or an opaque payload container -- never a
+# PII-shaped field (no email, name, username, ip_address, phone, address).
+STREAM_EVENT_ALLOWLIST = frozenset({"id", "stream", "data", "retry_count", "timestamp"})
+
+# Permitted keys in the dict handed to XADD for a main-stream publish.
+PUBLISH_ENVELOPE_ALLOWLIST = frozenset({"data", "timestamp", "retry_count"})
+
+# Permitted keys in the dict handed to XADD for a DLQ entry.
+DLQ_ENVELOPE_ALLOWLIST = frozenset(
+    {"original_id", "original_stream", "failure_reason", "retry_count", "timestamp", "data"}
+)
+
+
+def test_stream_event_dataclass_fields_match_allowlist(stream_pipeline_module):
+    """StreamEvent must declare exactly the allowlisted fields -- no more."""
+    actual_fields = {f.name for f in dataclasses.fields(stream_pipeline_module.StreamEvent)}
+    extra = actual_fields - STREAM_EVENT_ALLOWLIST
+    assert not extra, (
+        f"StreamEvent has field(s) outside the PII-safe allowlist: {sorted(extra)} -- "
+        "flag for review: is this PII-shaped, and if so tokenize to a UUID reference"
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_envelope_fields_match_allowlist(pipeline, fake_redis):
+    """The wire dict written for a main-stream publish carries no unexpected field."""
+    await pipeline.publish_event(
+        "events:commands",
+        {"command": "translate", "user_id": "11111111-1111-1111-1111-111111111111"},
+        max_len=100,
+    )
+
+    full_stream_name = pipeline._make_stream_name("events:commands")
+    entries = await fake_redis.xrange(full_stream_name)
+    assert len(entries) == 1
+    _, written_fields = entries[0]
+
+    extra = set(written_fields.keys()) - PUBLISH_ENVELOPE_ALLOWLIST
+    assert not extra, (
+        f"publish_event wrote unexpected envelope field(s): {sorted(extra)} -- "
+        "not on the PII-safe allowlist"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dlq_envelope_fields_match_allowlist(pipeline, fake_redis):
+    """The wire dict written for a DLQ entry carries no unexpected field."""
+    await pipeline.move_to_dlq(
+        "events:commands",
+        "1-0",
+        "max_retries_exceeded",
+        event_data={"user_id": "11111111-1111-1111-1111-111111111111"},
+        retry_count=3,
+    )
+
+    dlq_name = pipeline._make_dlq_name(pipeline._make_stream_name("events:commands"))
+    entries = await fake_redis.xrange(dlq_name)
+    assert len(entries) == 1
+    _, written_fields = entries[0]
+
+    extra = set(written_fields.keys()) - DLQ_ENVELOPE_ALLOWLIST
+    assert not extra, (
+        f"move_to_dlq wrote unexpected envelope field(s): {sorted(extra)} -- "
+        "not on the PII-safe allowlist"
+    )

--- a/tests/streams/test_retention.py
+++ b/tests/streams/test_retention.py
@@ -1,0 +1,108 @@
+"""
+GDPR retention-bound tests for StreamPipeline.
+
+`waddles:t:{tenant}:{stage}` and its DLQ are append-only Redis Streams --
+an unbounded stream is an unbounded retention period. The main stream
+write already took `maxlen`; the DLQ write did not (poison events, which
+sit longest, were exempt from the one control that matters most for
+them). This suite asserts every stream write StreamPipeline performs is
+bounded, and that the bound actually trims.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_dlq_maxlen_has_a_sane_default(pipeline):
+    """DLQ retention is a config knob with a default, not left unset."""
+    assert pipeline.dlq_maxlen == pipeline.DEFAULT_DLQ_MAXLEN
+    assert pipeline.dlq_maxlen > 0
+
+
+async def test_dlq_maxlen_is_configurable(fake_redis, stream_pipeline_module):
+    """Callers can override the DLQ bound (constructor arg wins over env default)."""
+    p = stream_pipeline_module.StreamPipeline(
+        redis_url="redis://fake", enabled=True, dlq_maxlen=5
+    )
+    p._redis = fake_redis
+    p._connected = True
+    assert p.dlq_maxlen == 5
+
+
+async def test_dlq_past_its_bound_is_trimmed(pipeline, fake_redis):
+    """Pushing well past dlq_maxlen entries leaves the DLQ at or below the bound.
+
+    This is the test that must fail against the unbounded `xadd(dlq_name,
+    dlq_data)` call and pass once `move_to_dlq` supplies `maxlen`.
+    """
+    pipeline.dlq_maxlen = 10
+    total_events = 50
+
+    for i in range(total_events):
+        ok = await pipeline.move_to_dlq(
+            stream_name="events:commands",
+            message_id=f"{i}-0",
+            error_reason="max_retries_exceeded",
+            event_data={"user_id": "11111111-1111-1111-1111-111111111111"},
+            retry_count=3,
+        )
+        assert ok is True
+
+    dlq_name = pipeline._make_dlq_name(pipeline._make_stream_name("events:commands"))
+    final_len = await fake_redis.xlen(dlq_name)
+
+    assert final_len <= pipeline.dlq_maxlen, (
+        f"DLQ grew to {final_len} entries, exceeding its {pipeline.dlq_maxlen} bound "
+        "-- unbounded retention (GDPR)"
+    )
+    assert final_len == pipeline.dlq_maxlen
+
+
+async def test_main_stream_past_its_bound_is_trimmed(pipeline, fake_redis):
+    """The main stream write's existing maxlen support actually trims."""
+    max_len = 10
+    total_events = 30
+
+    for i in range(total_events):
+        message_id = await pipeline.publish_event(
+            stream_name="events:commands",
+            event_data={"command_id": str(i)},
+            max_len=max_len,
+        )
+        assert message_id is not None
+
+    full_stream_name = pipeline._make_stream_name("events:commands")
+    final_len = await fake_redis.xlen(full_stream_name)
+
+    assert final_len <= max_len
+    assert final_len == max_len
+
+
+async def test_every_xadd_call_site_supplies_a_bound(pipeline, fake_redis):
+    """Regression guard: both stream-write paths must pass `maxlen`, unconditionally.
+
+    Wraps the fake's xadd to record whether maxlen was supplied on every
+    call, so a future call site added without a bound fails this test
+    rather than silently shipping unbounded retention.
+    """
+    calls: list[tuple[str, object]] = []
+    original_xadd = fake_redis.xadd
+
+    async def recording_xadd(name, fields, maxlen=None, approximate=True, id="*"):
+        calls.append((name, maxlen))
+        return await original_xadd(name, fields, maxlen=maxlen, approximate=approximate, id=id)
+
+    fake_redis.xadd = recording_xadd  # type: ignore[method-assign]
+
+    await pipeline.publish_event("events:commands", {"command": "translate"}, max_len=100)
+    await pipeline.move_to_dlq(
+        "events:commands", "1-0", "bad_payload", event_data={"x": "y"}
+    )
+
+    assert len(calls) == 2
+    for stream_name, maxlen in calls:
+        assert maxlen is not None, f"xadd to {stream_name} has no maxlen -- unbounded retention"


### PR DESCRIPTION
Task 0.7 (concrete parts). Bounded DLQ retention (`dlq_maxlen`, default 10000 — the DLQ xadd was unbounded, a GDPR retention problem); envelope PII allowlist test (transport clean; flags that the *payload* EventPayload/CommandRequest carries username/display_name for P1 tokenization); SBOM per image in CI via `anchore/sbom-action` (real SHA, pinned, ungated). 8 tests, fail-first proven for retention + PII. Consent-safe PostHog eval left as TODO (PostHog unwired).