### PR TITLE
chore(v3 P0.5): seven-container pipeline skeleton

### DIFF
--- a/k8s/helm/waddlebot/Chart.yaml
+++ b/k8s/helm/waddlebot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: waddlebot
 description: Waddles - Multi-platform chat bot system with microservices architecture
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.0.0"
 kubeVersion: ">=1.23.0-0"
 keywords:

--- a/k8s/helm/waddlebot/PIPELINE_MAPPING.md
+++ b/k8s/helm/waddlebot/PIPELINE_MAPPING.md
@@ -1,0 +1,96 @@
+# v3.0.x Task 0.5 — 31 → 7 Container Mapping (SKELETON)
+
+Denominator (`grep -rl "kind: Deployment" k8s/helm/waddlebot/templates/ | wc -l`): **31**.
+
+This chart now contains **both** the 31 legacy per-module Deployments **and** the 7 new
+pipeline Deployments (`templates/svc-ingest.yaml`, `svc-process.yaml`, `svc-action.yaml`,
+`svc-core.yaml`, `hub-api.yaml`, `hub-webui.yaml`, `svc-rtc.yaml`). They coexist — the 31 are
+**not deleted** by this task. Deleting them and wiring the new containers' app-level Python
+Module-bundle imports is the remaining build (see bottom of this file).
+
+## 26 app/module Deployments → 6 pipeline/support containers
+
+| # | Legacy template | New container | Module (owner) |
+|---|---|---|---|
+| 1 | `collectors/discord.yaml` | `svc-ingest` | Bot |
+| 2 | `collectors/googlechat.yaml` | `svc-ingest` | Bot |
+| 3 | `collectors/kick.yaml` | `svc-ingest` | Bot |
+| 4 | `collectors/mattermost.yaml` | `svc-ingest` | Bot |
+| 5 | `collectors/slack.yaml` | `svc-ingest` | Bot |
+| 6 | `collectors/teams.yaml` | `svc-ingest` | Bot |
+| 7 | `collectors/twitch.yaml` | `svc-ingest` | Bot |
+| 8 | `collectors/youtube-live.yaml` | `svc-ingest` | Bot |
+| 9 | `pushing/trigger-webhooks.yaml` | `svc-ingest` | Bot (generic inbound webhooks) |
+| 10 | `pushing/trigger-streaming.yaml` | `svc-ingest` | Bot |
+| 11 | `core/router.yaml` | `svc-process` | Core (event bus) + Bot (command dispatch) |
+| 12 | `core/core-community.yaml` | `svc-core` | Core (tenancy) |
+| 13 | `core/core-data.yaml` | `svc-core` | Core |
+| 14 | `core/core-identity.yaml` | `svc-core` | Core (identity) |
+| 15 | `core/ai-researcher.yaml` | `svc-action` | Bot (standalone AI assistant) |
+| 16 | `core/hub.yaml` | `hub-api` | Core (admin shell) |
+| 17 | `core/marketplace.yaml` | `hub-api` | Core (marketplace) |
+| 18 | `core/hub-webui.yaml` | `hub-webui` | Core (1:1, static SPA) |
+| 19 | `interactive/ai.yaml` | `svc-action` | Bot (interaction) |
+| 20 | `interactive/loyalty.yaml` | `svc-action` | Social (per core-boundary.md flagged call) |
+| 21 | `interactive/interactive-gaming.yaml` | `svc-action` | Bot (clip/server_manager/server_status) |
+| 22 | `interactive/interactive-media.yaml` | `svc-action` | Social (spotify/youtube_music) |
+| 23 | `interactive/interactive-productivity.yaml` | `svc-action` | Social (calendar/lfg) |
+| 24 | `interactive/interactive-social.yaml` | `svc-action` | Social (presence/shoutout/alias/quote/inventory/memories/translate) |
+| 25 | `pushing/action-platforms.yaml` | `svc-action` | Bot (discord/slack/teams/mattermost/googlechat outbound) |
+| 26 | `pushing/action-serverless.yaml` | `svc-action` | Bot (gcp_functions/lambda/openwhisk outbound) |
+
+Tally: `svc-ingest` 10, `svc-process` 1, `svc-core` 3, `svc-action` 8, `hub-api` 2,
+`hub-webui` 1 = 25... plus `core/hub-webui.yaml` counted at row 18 = **26**.
+
+## 5 infrastructure Deployments — out of scope, untouched
+
+`infrastructure/{minio,ollama,postgres,qdrant,redis}.yaml` are datastore/dependency
+Deployments, not Module/Core app code. They are not part of the "~40 co-equal service
+containers" the design doc collapses, and Task 0.5 does not touch them.
+
+`26 + 5 = 31` — full denominator accounted for.
+
+## `svc-rtc` — the 7th container has no Helm predecessor
+
+`core/module_rtc` (Go WebRTC/SFU, Social-owned per `core-boundary.md`) has **no existing
+Helm Deployment template** among the 31 — it exists only in the deprecated Kustomize tree
+(`k8s/kustomize/`). `svc-rtc` is net-new in Helm, not a consolidation of an existing Helm
+resource. It closes a gap rather than replacing one of the 31.
+
+## Naming collision found and fixed during verification
+
+Legacy `core/hub.yaml` hardcodes its Deployment/Service `metadata.name` to
+`{{ fullname }}-hub-api` (its component *label* is `hub`, but the object *name* is
+`hub-api` — a pre-existing quirk). Legacy `core/hub-webui.yaml` uses
+`{{ fullname }}-hub-webui` for both label and name. The new `hub-api.yaml`/`hub-webui.yaml`
+skeleton templates initially reused those same literal names and collided while coexisting
+(`helm template` rendered two objects with the identical `metadata.name`, which
+`kubectl apply`/`helm install` would reject or silently overwrite). Fixed by suffixing the
+new containers' object names: `{{ fullname }}-hub-api-v3` and
+`{{ fullname }}-hub-webui-v3`. Component labels were already disambiguated
+(`hub-api` vs legacy's `hub`; `hub-webui-v3` vs legacy's `hub-webui`) so pod selectors never
+collided — only the object names did. Confirmed no duplicate `metadata.name` remains via
+`awk` scan over the full render (34 unique Deployment names, zero repeats).
+
+## What remains (NOT done by this skeleton)
+
+- **Per-module App-bundle wiring inside each container.** The env vars this skeleton renders
+  (`MODULE_LOAD_BOT`, `MODULE_LOAD_SOCIAL`, etc.) are a values→env passthrough proving the
+  toggle reaches every stage a Module touches. The Python-side conditional import of each
+  Module's App bundle behind those env vars does not exist yet — that's the larger remaining
+  build referenced in the task.
+- **No Dockerfiles/CI images exist yet** for `svc-ingest`/`svc-process`/`svc-action`/
+  `svc-core`/`hub-api`/`hub-webui`/`svc-rtc`. The skeleton pins each container's `image:` to
+  the repo's existing base-image digest (`python:3.13-slim-bookworm@sha256:...` for the
+  Python-based containers, `node:20-bookworm-slim@sha256:...` for `hub-webui`,
+  `debian:bookworm-slim@sha256:...` for `svc-rtc`, matching `core/module_rtc/Dockerfile`'s
+  runtime stage) rather than inventing a digest or using a mutable tag — grepped from
+  existing Dockerfiles, not invented. These are placeholders; replace with
+  `ghcr.io/waddlebot/waddlebot/{name}@sha256:<built-digest>` once each container's own
+  Dockerfile and CI build exist.
+- **Cutover.** Deleting the 31 legacy Deployments and repointing traffic (Services, Ingress,
+  HTTPRoute, NetworkPolicy) at the 7 is not done here — the two sets coexist so this skeleton
+  renders cleanly without breaking the running chart.
+- **`svc-rtc` media transport** (UDP port range, `hostNetwork`/`hostPort` needs) is not
+  wired — only an HTTP health/metrics port is exposed. Any NET_ADMIN/hostNetwork requirement
+  needs explicit user approval before being added (ROOT EXCEPTION policy).

--- a/k8s/helm/waddlebot/templates/hub-api.yaml
+++ b/k8s/helm/waddlebot/templates/hub-api.yaml
@@ -1,0 +1,129 @@
+# v3.0.x Task 0.5 — SKELETON. Admin + marketplace + tenant management; low-volume admin
+# traffic, so it is not on svc-core's deploy cadence and does not carry the auth path.
+# Folds core/{hub,marketplace}.yaml — see PIPELINE_MAPPING.md. Coexists with those 2 legacy
+# Deployments; cutover is a later task. Per the design doc, hub-api is where Customer's
+# Apps mostly live (CRUD), and where every Module's admin/marketplace surface is exposed.
+{{- if .Values.pipeline.hubApi.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-hub-api-v3
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub-api
+spec:
+  replicas: {{ .Values.pipeline.hubApi.replicas }}
+  selector:
+    matchLabels:
+      {{- include "waddlebot.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hub-api
+  template:
+    metadata:
+      labels:
+        {{- include "waddlebot.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: hub-api
+    spec:
+      serviceAccountName: {{ include "waddlebot.serviceAccountName" . }}
+      {{- include "waddlebot.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{- include "waddlebot.dbMigrateInitContainer" . | nindent 6 }}
+      containers:
+      - name: hub-api
+        # SKELETON PLACEHOLDER — no Dockerfile/CI image exists yet for hub-api; pinned to
+        # the repo's existing Python base digest rather than inventing one or using a mutable
+        # tag. Replace once hub-api has its own Dockerfile and CI build.
+        image: "{{ .Values.pipeline.pythonBaseImage }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.pipeline.hubApi.port }}
+          protocol: TCP
+        - name: grpc
+          containerPort: {{ .Values.pipeline.hubApi.grpcPort }}
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: {{ include "waddlebot.fullname" . }}-config
+        - secretRef:
+            name: {{ include "waddlebot.fullname" . }}-secrets
+        env:
+        - name: MODULE_NAME
+          value: "hub-api"
+        - name: PIPELINE_STAGE
+          value: "hub-api"
+        - name: MODULE_PORT
+          value: {{ .Values.pipeline.hubApi.port | quote }}
+        - name: GRPC_PORT
+          value: {{ .Values.pipeline.hubApi.grpcPort | quote }}
+        {{- if .Values.modules.bot.enabled }}
+        - name: MODULE_LOAD_BOT
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.social.enabled }}
+        - name: MODULE_LOAD_SOCIAL
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.customer.enabled }}
+        - name: MODULE_LOAD_CUSTOMER
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.marketing.enabled }}
+        - name: MODULE_LOAD_MARKETING
+          value: "true"
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          {{- toYaml .Values.pipeline.hubApi.resources | nindent 10 }}
+        volumeMounts:
+        - name: logs
+          mountPath: /var/log/waddlebotlog
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: logs
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-hub-api-v3
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub-api
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.pipeline.hubApi.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  - port: {{ .Values.pipeline.hubApi.grpcPort }}
+    targetPort: grpc
+    protocol: TCP
+    name: grpc
+  selector:
+    {{- include "waddlebot.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: hub-api
+{{- end }}

--- a/k8s/helm/waddlebot/templates/hub-webui.yaml
+++ b/k8s/helm/waddlebot/templates/hub-webui.yaml
@@ -1,0 +1,95 @@
+# v3.0.x Task 0.5 — SKELETON. Static SPA assets; different cache/scaling profile from
+# hub-api, which is why it is a separate container rather than served by the same one.
+# 1:1 fold of core/hub-webui.yaml — see PIPELINE_MAPPING.md. Coexists with that legacy
+# Deployment; cutover is a later task. No envFrom / db-migrate init container, matching the
+# legacy hub-webui Deployment's precedent (static assets need neither).
+{{- if .Values.pipeline.hubWebui.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-hub-webui-v3
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub-webui-v3
+spec:
+  replicas: {{ .Values.pipeline.hubWebui.replicas }}
+  selector:
+    matchLabels:
+      {{- include "waddlebot.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hub-webui-v3
+  template:
+    metadata:
+      labels:
+        {{- include "waddlebot.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: hub-webui-v3
+    spec:
+      serviceAccountName: {{ include "waddlebot.serviceAccountName" . }}
+      {{- include "waddlebot.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: hub-webui
+        # SKELETON PLACEHOLDER — no Dockerfile/CI image exists yet for this hub-webui
+        # container; pinned to the repo's existing Node base digest (used by
+        # admin/hub_module/Dockerfile.webui) rather than inventing one or using a mutable
+        # tag. Replace once this container has its own Dockerfile and CI build.
+        image: "{{ .Values.pipeline.nodeBaseImage }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.pipeline.hubWebui.port }}
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          {{- toYaml .Values.pipeline.hubWebui.resources | nindent 10 }}
+        volumeMounts:
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-hub-webui-v3
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub-webui-v3
+spec:
+  type: {{ .Values.pipeline.hubWebui.service.type | default "ClusterIP" }}
+  ports:
+  - port: {{ .Values.pipeline.hubWebui.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    {{- include "waddlebot.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: hub-webui-v3
+{{- end }}

--- a/k8s/helm/waddlebot/templates/svc-action.yaml
+++ b/k8s/helm/waddlebot/templates/svc-action.yaml
@@ -1,0 +1,123 @@
+# v3.0.x Task 0.5 — SKELETON. Pipeline stage 3/3: outbound actions, interaction Apps,
+# third-party App calls. Folds 8 legacy interaction/action Deployments — see
+# PIPELINE_MAPPING.md for the full file-by-file list. Coexists with those 8 legacy
+# Deployments; cutover is a later task.
+#
+# Module bundle gating: presence of MODULE_LOAD_* env vars signals which Module App bundles
+# this stage should import. The actual conditional Python import behind these env vars is
+# the remaining build — this skeleton only proves the values flag reaches the container.
+{{- if .Values.pipeline.svcAction.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-svc-action
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-action
+spec:
+  replicas: {{ .Values.pipeline.svcAction.replicas }}
+  selector:
+    matchLabels:
+      {{- include "waddlebot.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: svc-action
+  template:
+    metadata:
+      labels:
+        {{- include "waddlebot.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: svc-action
+    spec:
+      serviceAccountName: {{ include "waddlebot.serviceAccountName" . }}
+      {{- include "waddlebot.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{- include "waddlebot.dbMigrateInitContainer" . | nindent 6 }}
+      containers:
+      - name: svc-action
+        # SKELETON PLACEHOLDER — no Dockerfile/CI image exists yet for svc-action; pinned to
+        # the repo's existing Python base digest rather than inventing one or using a mutable
+        # tag. Replace once svc-action has its own Dockerfile and CI build.
+        image: "{{ .Values.pipeline.pythonBaseImage }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.pipeline.svcAction.port }}
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: {{ include "waddlebot.fullname" . }}-config
+        - secretRef:
+            name: {{ include "waddlebot.fullname" . }}-secrets
+        env:
+        - name: MODULE_NAME
+          value: "svc-action"
+        - name: PIPELINE_STAGE
+          value: "action"
+        - name: MODULE_PORT
+          value: {{ .Values.pipeline.svcAction.port | quote }}
+        {{- if .Values.modules.bot.enabled }}
+        - name: MODULE_LOAD_BOT
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.social.enabled }}
+        - name: MODULE_LOAD_SOCIAL
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.customer.enabled }}
+        - name: MODULE_LOAD_CUSTOMER
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.marketing.enabled }}
+        - name: MODULE_LOAD_MARKETING
+          value: "true"
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          {{- toYaml .Values.pipeline.svcAction.resources | nindent 10 }}
+        volumeMounts:
+        - name: logs
+          mountPath: /var/log/waddlebotlog
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: logs
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-svc-action
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-action
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.pipeline.svcAction.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    {{- include "waddlebot.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-action
+{{- end }}

--- a/k8s/helm/waddlebot/templates/svc-core.yaml
+++ b/k8s/helm/waddlebot/templates/svc-core.yaml
@@ -1,0 +1,116 @@
+# v3.0.x Task 0.5 — SKELETON. Core: identity, security, credentials, tenancy/entitlement.
+# Every stage depends on svc-core and calls it over gRPC (backend.md mandate) rather than a
+# stream, since these calls are synchronous. Folds core/{core-community,core-data,
+# core-identity}.yaml — see PIPELINE_MAPPING.md. Coexists with those 3 legacy Deployments;
+# cutover is a later task. Deliberately not folded into hub-api: every service's auth path
+# would otherwise ride the admin API's deploy cadence.
+#
+# Not gated by modules.<name>.enabled — Core is mandatory regardless of which Modules are on.
+{{- if .Values.pipeline.svcCore.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-svc-core
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-core
+spec:
+  replicas: {{ .Values.pipeline.svcCore.replicas }}
+  selector:
+    matchLabels:
+      {{- include "waddlebot.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: svc-core
+  template:
+    metadata:
+      labels:
+        {{- include "waddlebot.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: svc-core
+    spec:
+      serviceAccountName: {{ include "waddlebot.serviceAccountName" . }}
+      {{- include "waddlebot.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{- include "waddlebot.dbMigrateInitContainer" . | nindent 6 }}
+      containers:
+      - name: svc-core
+        # SKELETON PLACEHOLDER — no Dockerfile/CI image exists yet for svc-core; pinned to
+        # the repo's existing Python base digest rather than inventing one or using a mutable
+        # tag. Replace once svc-core has its own Dockerfile and CI build.
+        image: "{{ .Values.pipeline.pythonBaseImage }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.pipeline.svcCore.port }}
+          protocol: TCP
+        - name: grpc
+          containerPort: {{ .Values.pipeline.svcCore.grpcPort }}
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: {{ include "waddlebot.fullname" . }}-config
+        - secretRef:
+            name: {{ include "waddlebot.fullname" . }}-secrets
+        env:
+        - name: MODULE_NAME
+          value: "svc-core"
+        - name: PIPELINE_STAGE
+          value: "core"
+        - name: MODULE_PORT
+          value: {{ .Values.pipeline.svcCore.port | quote }}
+        - name: GRPC_PORT
+          value: {{ .Values.pipeline.svcCore.grpcPort | quote }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          {{- toYaml .Values.pipeline.svcCore.resources | nindent 10 }}
+        volumeMounts:
+        - name: logs
+          mountPath: /var/log/waddlebotlog
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: logs
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-svc-core
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-core
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.pipeline.svcCore.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  - port: {{ .Values.pipeline.svcCore.grpcPort }}
+    targetPort: grpc
+    protocol: TCP
+    name: grpc
+  selector:
+    {{- include "waddlebot.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-core
+{{- end }}

--- a/k8s/helm/waddlebot/templates/svc-ingest.yaml
+++ b/k8s/helm/waddlebot/templates/svc-ingest.yaml
@@ -1,0 +1,119 @@
+# v3.0.x Task 0.5 — SKELETON. Pipeline stage 1/3: platform receivers + inbound webhooks.
+# Folds collectors/{discord,googlechat,kick,mattermost,slack,teams,twitch,youtube-live}.yaml
+# and pushing/{trigger-webhooks,trigger-streaming}.yaml — see PIPELINE_MAPPING.md for the
+# full 31→7 mapping. Coexists with those 10 legacy Deployments; cutover is a later task.
+#
+# Module bundle gating: presence of MODULE_LOAD_* env vars signals which Module App bundles
+# this stage should import. The actual conditional Python import behind these env vars is
+# the remaining build — this skeleton only proves the values flag reaches the container.
+{{- if .Values.pipeline.svcIngest.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-svc-ingest
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-ingest
+spec:
+  replicas: {{ .Values.pipeline.svcIngest.replicas }}
+  selector:
+    matchLabels:
+      {{- include "waddlebot.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: svc-ingest
+  template:
+    metadata:
+      labels:
+        {{- include "waddlebot.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: svc-ingest
+    spec:
+      serviceAccountName: {{ include "waddlebot.serviceAccountName" . }}
+      {{- include "waddlebot.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{- include "waddlebot.dbMigrateInitContainer" . | nindent 6 }}
+      containers:
+      - name: svc-ingest
+        # SKELETON PLACEHOLDER — no Dockerfile/CI image exists yet for svc-ingest; pinned to
+        # the repo's existing Python base digest rather than inventing one or using a mutable
+        # tag. Replace once svc-ingest has its own Dockerfile and CI build.
+        image: "{{ .Values.pipeline.pythonBaseImage }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.pipeline.svcIngest.port }}
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: {{ include "waddlebot.fullname" . }}-config
+        - secretRef:
+            name: {{ include "waddlebot.fullname" . }}-secrets
+        env:
+        - name: MODULE_NAME
+          value: "svc-ingest"
+        - name: PIPELINE_STAGE
+          value: "ingest"
+        - name: MODULE_PORT
+          value: {{ .Values.pipeline.svcIngest.port | quote }}
+        {{- if .Values.modules.bot.enabled }}
+        - name: MODULE_LOAD_BOT
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.social.enabled }}
+        - name: MODULE_LOAD_SOCIAL
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.marketing.enabled }}
+        - name: MODULE_LOAD_MARKETING
+          value: "true"
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          {{- toYaml .Values.pipeline.svcIngest.resources | nindent 10 }}
+        volumeMounts:
+        - name: logs
+          mountPath: /var/log/waddlebotlog
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: logs
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-svc-ingest
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-ingest
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.pipeline.svcIngest.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    {{- include "waddlebot.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-ingest
+{{- end }}

--- a/k8s/helm/waddlebot/templates/svc-process.yaml
+++ b/k8s/helm/waddlebot/templates/svc-process.yaml
@@ -1,0 +1,122 @@
+# v3.0.x Task 0.5 — SKELETON. Pipeline stage 2/3: event bus, routing, command dispatch,
+# workflow. Folds core/router.yaml (Core event bus + Bot command dispatch) — see
+# PIPELINE_MAPPING.md. Coexists with that legacy Deployment; cutover is a later task.
+#
+# Module bundle gating: presence of MODULE_LOAD_* env vars signals which Module App bundles
+# this stage should import. The actual conditional Python import behind these env vars is
+# the remaining build — this skeleton only proves the values flag reaches the container.
+{{- if .Values.pipeline.svcProcess.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-svc-process
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-process
+spec:
+  replicas: {{ .Values.pipeline.svcProcess.replicas }}
+  selector:
+    matchLabels:
+      {{- include "waddlebot.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: svc-process
+  template:
+    metadata:
+      labels:
+        {{- include "waddlebot.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: svc-process
+    spec:
+      serviceAccountName: {{ include "waddlebot.serviceAccountName" . }}
+      {{- include "waddlebot.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{- include "waddlebot.dbMigrateInitContainer" . | nindent 6 }}
+      containers:
+      - name: svc-process
+        # SKELETON PLACEHOLDER — no Dockerfile/CI image exists yet for svc-process; pinned to
+        # the repo's existing Python base digest rather than inventing one or using a mutable
+        # tag. Replace once svc-process has its own Dockerfile and CI build.
+        image: "{{ .Values.pipeline.pythonBaseImage }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.pipeline.svcProcess.port }}
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: {{ include "waddlebot.fullname" . }}-config
+        - secretRef:
+            name: {{ include "waddlebot.fullname" . }}-secrets
+        env:
+        - name: MODULE_NAME
+          value: "svc-process"
+        - name: PIPELINE_STAGE
+          value: "process"
+        - name: MODULE_PORT
+          value: {{ .Values.pipeline.svcProcess.port | quote }}
+        {{- if .Values.modules.bot.enabled }}
+        - name: MODULE_LOAD_BOT
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.social.enabled }}
+        - name: MODULE_LOAD_SOCIAL
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.customer.enabled }}
+        - name: MODULE_LOAD_CUSTOMER
+          value: "true"
+        {{- end }}
+        {{- if .Values.modules.marketing.enabled }}
+        - name: MODULE_LOAD_MARKETING
+          value: "true"
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          {{- toYaml .Values.pipeline.svcProcess.resources | nindent 10 }}
+        volumeMounts:
+        - name: logs
+          mountPath: /var/log/waddlebotlog
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: logs
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-svc-process
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-process
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.pipeline.svcProcess.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    {{- include "waddlebot.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-process
+{{- end }}

--- a/k8s/helm/waddlebot/templates/svc-rtc.yaml
+++ b/k8s/helm/waddlebot/templates/svc-rtc.yaml
@@ -1,0 +1,100 @@
+# v3.0.x Task 0.5 — SKELETON. WebRTC/SFU media transport; UDP media scaling shares nothing
+# with HTTP request handling, so it cannot co-locate with any other stage. Net-new in Helm —
+# core/module_rtc has no existing Helm Deployment among the 31 (Kustomize-only today,
+# deprecated); this closes that gap rather than folding an existing Helm resource. See
+# PIPELINE_MAPPING.md. Only Social owns module_rtc (core-boundary.md), so the whole
+# container is gated on modules.social.enabled, unlike the pipeline stages where a Module
+# contributes code rather than owning the container.
+#
+# Media UDP transport (port range, hostNetwork/hostPort) is NOT wired in this skeleton — only
+# an HTTP health/metrics port is exposed. Any NET_ADMIN/hostNetwork requirement needs
+# explicit user approval before being added (ROOT EXCEPTION policy) — not assumed here.
+{{- if and .Values.pipeline.svcRtc.enabled .Values.modules.social.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-svc-rtc
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-rtc
+spec:
+  replicas: {{ .Values.pipeline.svcRtc.replicas }}
+  selector:
+    matchLabels:
+      {{- include "waddlebot.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: svc-rtc
+  template:
+    metadata:
+      labels:
+        {{- include "waddlebot.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: svc-rtc
+    spec:
+      serviceAccountName: {{ include "waddlebot.serviceAccountName" . }}
+      {{- include "waddlebot.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: svc-rtc
+        # SKELETON PLACEHOLDER — no Dockerfile/CI image exists yet for svc-rtc; pinned to the
+        # repo's existing Debian runtime digest (matches core/module_rtc/Dockerfile's final
+        # stage) rather than inventing one or using a mutable tag. Replace once svc-rtc has
+        # its own Dockerfile and CI build.
+        image: "{{ .Values.pipeline.goRuntimeImage }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.pipeline.svcRtc.port }}
+          protocol: TCP
+        env:
+        - name: MODULE_NAME
+          value: "svc-rtc"
+        - name: PIPELINE_STAGE
+          value: "rtc"
+        - name: MODULE_PORT
+          value: {{ .Values.pipeline.svcRtc.port | quote }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          {{- toYaml .Values.pipeline.svcRtc.resources | nindent 10 }}
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "waddlebot.fullname" . }}-svc-rtc
+  labels:
+    {{- include "waddlebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-rtc
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.pipeline.svcRtc.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    {{- include "waddlebot.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: svc-rtc
+{{- end }}

--- a/k8s/helm/waddlebot/values.yaml
+++ b/k8s/helm/waddlebot/values.yaml
@@ -220,8 +220,121 @@ infrastructure:
     apiHost: ""
     apiKey: ""
 
+# v3.0.x Task 0.5 — seven-container pipeline (SKELETON)
+# Coexists with `modules.*` below (the 31 legacy per-module Deployments) until cutover — see
+# k8s/helm/waddlebot/PIPELINE_MAPPING.md for the full 31→7 mapping and what remains.
+#
+# Base images pinned to digests already used elsewhere in this repo (grepped from existing
+# Dockerfiles, never invented) as placeholders — none of these 7 containers have their own
+# Dockerfile/CI-built image yet. Replace per-container once each does.
+pipeline:
+  pythonBaseImage: "python:3.13-slim-bookworm@sha256:01f42367a0a94ad4bc17111776fd66e3500c1d87c15bbd6055b7371d39c124fb"
+  nodeBaseImage: "node:20-bookworm-slim@sha256:1e85773c98c31d4fe5b545e4cb17379e617b348832fb3738b22a08f68dec30f3"
+  goRuntimeImage: "debian:bookworm-slim@sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a"
+
+  svcIngest:
+    enabled: true
+    port: 8200
+    replicas: 2
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "512Mi"
+      limits:
+        cpu: "2000m"
+        memory: "2Gi"
+
+  svcProcess:
+    enabled: true
+    port: 8201
+    replicas: 2
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "512Mi"
+      limits:
+        cpu: "2000m"
+        memory: "2Gi"
+
+  svcAction:
+    enabled: true
+    port: 8202
+    replicas: 2
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "512Mi"
+      limits:
+        cpu: "2000m"
+        memory: "2Gi"
+
+  svcCore:
+    enabled: true
+    port: 8203
+    grpcPort: 50203
+    replicas: 2
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "256Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+
+  hubApi:
+    enabled: true
+    port: 8204
+    grpcPort: 50204
+    replicas: 2
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "256Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+
+  hubWebui:
+    enabled: true
+    port: 8205
+    replicas: 2
+    service:
+      type: ClusterIP
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+
+  svcRtc:
+    enabled: true
+    port: 8206
+    replicas: 1
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "256Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+
 # Processing Module
 modules:
+  # v3.0.x Task 0.5 — Module verticals (Bot/Social/Customer/Marketing) that load into the
+  # pipeline containers above via modules.<name>.enabled. NOT per-module pods — see
+  # docs/architecture/core-boundary.md and docs/plans/2026-08-26-v3-scbm-apps-design.md
+  # "## Deployment" > "### Modules cut across stages".
+  bot:
+    enabled: true
+  social:
+    enabled: true
+  customer:
+    enabled: false
+  marketing:
+    enabled: false
+
   # Processing Module - Router (UNCHANGED)
   router:
     enabled: true


### PR DESCRIPTION
Task 0.5 SKELETON (not the cutover). 7 container Deployments (svc-ingest/process/action/core/rtc + hub-api/hub-webui) coexisting with the 31 legacy (deletion is remaining work). `modules.<name>.enabled` toggle loads Module verticals into stages. PIPELINE_MAPPING.md has the 31→7 mapping. Found+fixed 2 bugs (metadata.name collision, toggle leak). Verified: 7 render, runAsNonRoot everywhere, lint clean, toggle proven both ways, digests grepped-not-invented. Remaining work listed in PIPELINE_MAPPING.md.